### PR TITLE
RSDK-828 - fix file handle leak

### DIFF
--- a/src/ffi/dial_ffi.rs
+++ b/src/ffi/dial_ffi.rs
@@ -176,7 +176,7 @@ pub unsafe extern "C" fn dial(
         disable_webrtc = uri_str.contains(".local") || uri_str.contains("localhost");
     }
     let (server, channel) = match runtime.block_on(async move {
-        let dial = match payload {
+        let channel = match payload {
             Some(p) => Either::A(
                 dial_with_cred(uri_str, p.to_str()?, allow_insec, disable_webrtc)?
                     .connect()
@@ -187,7 +187,7 @@ pub unsafe extern "C" fn dial(
                 Either::B(c.connect().await?)
             }
         };
-        let channel = dial.clone();
+        let dial = channel.clone();
         let g = GRPCProxy::new(dial, uri);
         let service = ServiceBuilder::new()
             .layer(

--- a/src/ffi/dial_ffi.rs
+++ b/src/ffi/dial_ffi.rs
@@ -253,6 +253,12 @@ pub extern "C" fn free_rust_runtime(rt_ptr: Option<Box<DialFfi>>) -> i32 {
             return -1;
         }
     };
+    if let Some(sigs) = ctx.sigs.take() {
+        for sig in sigs {
+            let _ = sig.send(());
+        }
+    }
+
     for channel in &ctx.channels {
         let channel = match channel {
             Either::A(chan) => chan.get_ref(),
@@ -267,12 +273,6 @@ pub extern "C" fn free_rust_runtime(rt_ptr: Option<Box<DialFfi>>) -> i32 {
                 .unwrap_or_default(),
         }
     }
-    if let Some(sigs) = ctx.sigs.take() {
-        for sig in sigs {
-            let _ = sig.send(());
-        }
-    }
-
     log::debug!("Freeing rust runtime");
     0
 }

--- a/src/ffi/dial_ffi.rs
+++ b/src/ffi/dial_ffi.rs
@@ -212,7 +212,7 @@ pub unsafe extern "C" fn dial(
             return ptr::null_mut();
         }
     };
-    ctx.channels.append(&mut vec![channel]);
+    ctx.channels.push(channel);
     let server = server.with_graceful_shutdown(async {
         rx.await.ok();
     });

--- a/src/ffi/spatialmath/vector3.rs
+++ b/src/ffi/spatialmath/vector3.rs
@@ -13,42 +13,42 @@ pub unsafe extern "C" fn free_vector_memory(ptr: *mut Vector3) {
     if ptr.is_null() {
         return;
     }
-    Box::from_raw(ptr);
+    let _ = Box::from_raw(ptr);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn vector_get_components(vec_ptr: *const Vector3) -> *const c_double {
     null_pointer_check!(vec_ptr);
     let vec = *vec_ptr;
-    let components: [c_double;3] = [vec.x, vec.y, vec.z];
+    let components: [c_double; 3] = [vec.x, vec.y, vec.z];
     Box::into_raw(Box::new(components)) as *const _
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn vector_set_x(vec_ptr: *mut Vector3, x_val: f64) {
     null_pointer_check!(vec_ptr);
-    let vec = &mut*vec_ptr;
+    let vec = &mut *vec_ptr;
     vec.x = x_val
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn vector_set_y(vec_ptr: *mut Vector3, y_val: f64) {
     null_pointer_check!(vec_ptr);
-    let vec = &mut*vec_ptr;
+    let vec = &mut *vec_ptr;
     vec.y = y_val
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn vector_set_z(vec_ptr: *mut Vector3, z_val: f64) {
     null_pointer_check!(vec_ptr);
-    let vec = &mut*vec_ptr;
+    let vec = &mut *vec_ptr;
     vec.z = z_val
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn normalize_vector(vec_ptr: *mut Vector3) {
     null_pointer_check!(vec_ptr);
-    let vec = &mut*vec_ptr;
+    let vec = &mut *vec_ptr;
     vec.normalize();
 }
 
@@ -63,7 +63,7 @@ pub unsafe extern "C" fn vector_get_normalized(vec_ptr: *const Vector3) -> *mut 
 #[no_mangle]
 pub unsafe extern "C" fn scale_vector(vec_ptr: *mut Vector3, factor: f64) {
     null_pointer_check!(vec_ptr);
-    let vec = &mut*vec_ptr;
+    let vec = &mut *vec_ptr;
     vec.scale(factor);
 }
 
@@ -77,7 +77,8 @@ pub unsafe extern "C" fn vector_get_scaled(vec_ptr: *const Vector3, factor: f64)
 
 #[no_mangle]
 pub unsafe extern "C" fn vector_add(
-    vec_ptr_1: *const Vector3, vec_ptr_2: *const Vector3
+    vec_ptr_1: *const Vector3,
+    vec_ptr_2: *const Vector3,
 ) -> *mut Vector3 {
     null_pointer_check!(vec_ptr_1);
     null_pointer_check!(vec_ptr_2);
@@ -88,7 +89,8 @@ pub unsafe extern "C" fn vector_add(
 
 #[no_mangle]
 pub unsafe extern "C" fn vector_subtract(
-    vec_ptr_1: *const Vector3, vec_ptr_2: *const Vector3
+    vec_ptr_1: *const Vector3,
+    vec_ptr_2: *const Vector3,
 ) -> *mut Vector3 {
     null_pointer_check!(vec_ptr_1);
     null_pointer_check!(vec_ptr_2);
@@ -98,7 +100,10 @@ pub unsafe extern "C" fn vector_subtract(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn vector_dot_product(vec_ptr_1: *const Vector3, vec_ptr_2: *const Vector3) -> f64 {
+pub unsafe extern "C" fn vector_dot_product(
+    vec_ptr_1: *const Vector3,
+    vec_ptr_2: *const Vector3,
+) -> f64 {
     null_pointer_check!(vec_ptr_1, f64::NAN);
     null_pointer_check!(vec_ptr_2, f64::NAN);
     let vec1 = &*vec_ptr_1;
@@ -108,12 +113,13 @@ pub unsafe extern "C" fn vector_dot_product(vec_ptr_1: *const Vector3, vec_ptr_2
 
 #[no_mangle]
 pub unsafe extern "C" fn vector_cross_product(
-    vec_ptr_1: *mut Vector3, vec_ptr_2: *mut Vector3
+    vec_ptr_1: *mut Vector3,
+    vec_ptr_2: *mut Vector3,
 ) -> *mut Vector3 {
     null_pointer_check!(vec_ptr_1);
     null_pointer_check!(vec_ptr_2);
-    let vec1 = &mut*vec_ptr_1;
-    let vec2 = &mut*vec_ptr_2;
+    let vec1 = &mut *vec_ptr_1;
+    let vec2 = &mut *vec_ptr_2;
     let vec = vec1.cross(vec2);
     vec.to_raw_pointer()
 }

--- a/src/rpc/client_channel.rs
+++ b/src/rpc/client_channel.rs
@@ -7,9 +7,12 @@ use anyhow::Result;
 use chashmap::CHashMap;
 use hyper::Body;
 use prost::Message;
-use std::sync::{
-    atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering},
-    Arc,
+use std::{
+    fmt::Debug,
+    sync::{
+        atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering},
+        Arc,
+    },
 };
 use webrtc::{
     data_channel::{data_channel_message::DataChannelMessage, RTCDataChannel},
@@ -27,7 +30,28 @@ pub struct WebRTCClientChannel {
     pub(crate) receiver_bodies: CHashMap<u64, hyper::Body>,
 }
 
+impl Debug for WebRTCClientChannel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebRTCClientChannel")
+            .field("stream_id_counter", &self.stream_id_counter)
+            .field("base channel", &self.base_channel.data_channel.id())
+            .field("base channel", &self.base_channel)
+            .finish()
+    }
+}
+
+impl Drop for WebRTCClientChannel {
+    fn drop(&mut self) {
+        log::error!("Dropping client counts  {:?}", &self.base_channel);
+    }
+}
+
 impl WebRTCClientChannel {
+    pub async fn close(&self) {
+        self.base_channel.close().await.unwrap();
+        self.base_channel.data_channel.close().await.unwrap();
+        self.base_channel.peer_connection.close().await.unwrap();
+    }
     pub(crate) async fn new(
         peer_connection: Arc<RTCPeerConnection>,
         data_channel: Arc<RTCDataChannel>,
@@ -42,17 +66,25 @@ impl WebRTCClientChannel {
 
         let channel = Arc::new(channel);
         let ret_channel = channel.clone();
+        let channel = Arc::downgrade(&channel);
 
         data_channel
             .on_message(Box::new(move |msg: DataChannelMessage| {
                 let channel = channel.clone();
                 Box::pin(async move {
+                    let channel = match channel.upgrade() {
+                        Some(channel) => channel,
+                        None => {
+                            return;
+                        }
+                    };
                     if let Err(e) = channel.on_channel_message(msg).await {
                         log::error!("error deserializing message: {e}");
                     }
                 })
             }))
             .await;
+        log::error!("Channel created");
         ret_channel
     }
 

--- a/src/rpc/client_channel.rs
+++ b/src/rpc/client_channel.rs
@@ -49,7 +49,7 @@ impl Drop for WebRTCClientChannel {
                 }
             });
         };
-        log::info!("Dropping client channel {:?}", &self);
+        log::debug!("Dropping client channel {:?}", &self);
     }
 }
 
@@ -91,7 +91,7 @@ impl WebRTCClientChannel {
                 })
             }))
             .await;
-        log::info!("Client channel created");
+        log::debug!("Client channel created");
         ret_channel
     }
 

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -29,14 +29,11 @@ use anyhow::{Context, Result};
 use core::fmt;
 use std::{
     collections::HashMap,
-    process,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, RwLock,
     },
     task::{Context as TaskContext, Poll},
-    thread::sleep,
-    time::Duration,
 };
 use tonic::body::BoxBody;
 use tonic::codegen::{http, BoxFuture};

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -29,11 +29,14 @@ use anyhow::{Context, Result};
 use core::fmt;
 use std::{
     collections::HashMap,
+    process,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, RwLock,
     },
     task::{Context as TaskContext, Poll},
+    thread::sleep,
+    time::Duration,
 };
 use tonic::body::BoxBody;
 use tonic::codegen::{http, BoxFuture};
@@ -583,7 +586,7 @@ async fn maybe_connect_via_webrtc(
     };
 
     let client_channel = WebRTCClientChannel::new(peer_connection, data_channel).await;
-    let client_channel_for_ice_gathering_thread = Arc::downgrade(&client_channel.clone());
+    let client_channel_for_ice_gathering_thread = Arc::downgrade(&client_channel);
     let mut signaling_client = SignalingServiceClient::new(channel.clone());
     let mut call_client = signaling_client.call(call_request).await?.into_inner();
 

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -494,7 +494,6 @@ async fn maybe_connect_via_webrtc(
     let uuid_for_ice_gathering_thread = uuid_lock.clone();
     let is_open = Arc::new(AtomicBool::new(false));
     let is_open_read = is_open.clone();
-
     data_channel
         .on_open(Box::new(move || {
             is_open.store(true, Ordering::Release);
@@ -584,7 +583,7 @@ async fn maybe_connect_via_webrtc(
     };
 
     let client_channel = WebRTCClientChannel::new(peer_connection, data_channel).await;
-    let client_channel_for_ice_gathering_thread = client_channel.clone();
+    let client_channel_for_ice_gathering_thread = Arc::downgrade(&client_channel.clone());
     let mut signaling_client = SignalingServiceClient::new(channel.clone());
     let mut call_client = signaling_client.call(call_request).await?.into_inner();
 
@@ -646,17 +645,29 @@ async fn maybe_connect_via_webrtc(
                             break;
                         }
                     };
-
-                    if let Err(e) = client_channel
-                        .base_channel
-                        .peer_connection
-                        .set_remote_description(answer)
-                        .await
                     {
-                        let e = anyhow::Error::from(e);
-                        send_error_once(sent_done.clone(), &response.uuid, &e, channel2.clone())
+                        let cc = match client_channel.upgrade() {
+                            Some(cc) => cc,
+                            None => {
+                                break;
+                            }
+                        };
+                        if let Err(e) = cc
+                            .base_channel
+                            .peer_connection
+                            .set_remote_description(answer)
+                            .await
+                        {
+                            let e = anyhow::Error::from(e);
+                            send_error_once(
+                                sent_done.clone(),
+                                &response.uuid,
+                                &e,
+                                channel2.clone(),
+                            )
                             .await;
-                        break;
+                            break;
+                        }
                     }
                     remote_description_set.store(true, Ordering::Release);
                     if webrtc_options.disable_trickle_ice {
@@ -684,6 +695,12 @@ async fn maybe_connect_via_webrtc(
                     }
                     match ice_candidate_from_proto(update.candidate) {
                         Ok(candidate) => {
+                            let client_channel = match client_channel.upgrade() {
+                                Some(cc) => cc,
+                                None => {
+                                    break;
+                                }
+                            };
                             if let Err(e) = client_channel
                                 .base_channel
                                 .peer_connection


### PR DESCRIPTION
Uses weak arc to ensure arcs are dropped appropriately, calls `close` on channels when freeing rust runtime in FFI context.