### PR TITLE
RSDK-2011 Change CHashMap to DashMap for better performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ anyhow = { version = "1.0", features = ["backtrace"]}
 base64 = "0.13.0"
 byteorder = "1.4.3"
 bytes = "1.1.0"
-chashmap = "2.2.2"
 derivative = "2.2.0"
 ffi_helpers = "0.3.0"
 float-cmp = "0.9.0"
@@ -45,6 +44,7 @@ tracing = {version = "0.1.34"}
 tracing-subscriber = {version = "0.3.11", features = ["env-filter"]}
 webpki-roots = "0.21.1"
 webrtc = "0.6.0"
+dashmap = "5.4.0"
 
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = { version = "1.0", features = ["backtrace"]}
 base64 = "0.13.0"
 byteorder = "1.4.3"
 bytes = "1.1.0"
+dashmap = "5.4.0"
 derivative = "2.2.0"
 ffi_helpers = "0.3.0"
 float-cmp = "0.9.0"
@@ -44,7 +45,6 @@ tracing = {version = "0.1.34"}
 tracing-subscriber = {version = "0.3.11", features = ["env-filter"]}
 webpki-roots = "0.21.1"
 webrtc = "0.6.0"
-dashmap = "5.4.0"
 
 
 [build-dependencies]


### PR DESCRIPTION
[RSDK-2011](https://viam.atlassian.net/browse/RSDK-2011)

[`DashMap`](https://crates.io/crates/dashmap) has an almost identical API to [`CHashMap`](https://crates.io/crates/chashmap) but anecdotally has better performance under high workloads (e.g. lots of concurrent writes). Switching to `DashMap` seems to resolve hangs with async calls from the Python SDK (see RSDK-2011 and [RSDK-2070](https://viam.atlassian.net/browse/RSDK-2070)).

Note that users will still run into the issue of stream ID integer overflow in the underlying `webrtc-rs` crate until we do [RSDK-2268](https://viam.atlassian.net/browse/RSDK-2268).

[RSDK-2011]: https://viam.atlassian.net/browse/RSDK-2011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RSDK-2070]: https://viam.atlassian.net/browse/RSDK-2070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RSDK-2268]: https://viam.atlassian.net/browse/RSDK-2268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ