### PR TITLE
RSDK-2268 - Update webrtc version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tower-http = { version = "0.3.3", features = ["add-extension","auth","propagate-
 tracing = {version = "0.1.34"}
 tracing-subscriber = {version = "0.3.11", features = ["env-filter"]}
 webpki-roots = "0.21.1"
-webrtc = "0.6.0"
+webrtc = "0.7.1"
 
 
 [build-dependencies]

--- a/src/rpc/base_channel.rs
+++ b/src/rpc/base_channel.rs
@@ -5,6 +5,8 @@ use std::{
         atomic::{AtomicBool, AtomicPtr, Ordering},
         Arc,
     },
+    thread::sleep,
+    time::Duration,
 };
 use webrtc::{data_channel::RTCDataChannel, peer_connection::RTCPeerConnection};
 
@@ -15,6 +17,7 @@ pub struct WebRTCBaseChannel {
     pub(crate) data_channel: Arc<RTCDataChannel>,
     closed_reason: AtomicPtr<Option<anyhow::Error>>,
     closed: AtomicBool,
+    pub(crate) should_close: AtomicBool,
 }
 
 impl Debug for WebRTCBaseChannel {
@@ -27,7 +30,30 @@ impl Debug for WebRTCBaseChannel {
 }
 
 impl WebRTCBaseChannel {
-    pub(crate) async fn new(
+    async fn close_loop(c: std::sync::Weak<Self>) {
+        let c = match c.upgrade() {
+            Some(c) => c,
+            None => return (),
+        };
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async move {
+            loop {
+                sleep(Duration::from_millis(100));
+                if !c.should_close.load(Ordering::Acquire) {
+                    continue;
+                }
+                if let Err(e) = c.close_with_reason().await {
+                    log::error!("error closing channel: {e}")
+                }
+                break;
+            }
+        })
+    }
+
+    async fn new_(
         peer_connection: Arc<RTCPeerConnection>,
         data_channel: Arc<RTCDataChannel>,
     ) -> Arc<Self> {
@@ -56,6 +82,7 @@ impl WebRTCBaseChannel {
             data_channel,
             closed_reason: AtomicPtr::new(&mut None),
             closed: AtomicBool::new(false),
+            should_close: AtomicBool::new(false),
         });
 
         let c = Arc::downgrade(&channel);
@@ -65,22 +92,35 @@ impl WebRTCBaseChannel {
                 None => return Box::pin(async {}),
             };
             Box::pin(async move {
-                if let Err(e) = c.close_with_reason(Some(anyhow::Error::from(err))).await {
-                    log::error!("error closing channel: {e}")
-                }
+                let mut err = Some(anyhow::Error::from(err));
+                c.closed_reason.store(&mut err, Ordering::Release);
+                c.should_close.store(true, Ordering::Release);
+                // CR erodkin: clean up!
+                //Box::pin(async move {
+                //if let Err(e) = c.close_with_reason(Some(anyhow::Error::from(err))).await {
+                //log::error!("error closing channel: {e}")
+                //}
             })
         }));
 
         channel
     }
 
-    async fn close_with_reason(&self, err: Option<anyhow::Error>) -> Result<()> {
-        let mut err = err;
+    pub(crate) async fn new(
+        peer_connection: Arc<RTCPeerConnection>,
+        data_channel: Arc<RTCDataChannel>,
+    ) -> Arc<Self> {
+        let chan = Self::new_(peer_connection, data_channel).await;
+        let c = Arc::downgrade(&chan);
+        tokio::task::spawn(async move { Self::close_loop(c) });
+        chan
+    }
+
+    async fn close_with_reason(&self) -> Result<()> {
         if self.closed.load(Ordering::Acquire) {
             return Ok(());
         }
         self.closed.store(true, Ordering::Release);
-        self.closed_reason.store(&mut err, Ordering::Release);
 
         self.peer_connection
             .close()
@@ -91,7 +131,7 @@ impl WebRTCBaseChannel {
     /// Closes the channel
     #[allow(dead_code)]
     pub async fn close(&self) -> Result<()> {
-        self.close_with_reason(None).await
+        self.close_with_reason().await
     }
     /// Returns whether or not the channel is closed
     #[allow(dead_code)]

--- a/src/rpc/client_channel.rs
+++ b/src/rpc/client_channel.rs
@@ -21,6 +21,9 @@ use webrtc::{
 
 // see golang/client_stream.go
 const MAX_REQUEST_MESSAGE_PACKET_DATA_SIZE: usize = 16373;
+// 256 is an arbitrarily high number for maximum concurrent streams, determined based on
+// analogous value in goutils
+const MAX_CONCURRENT_STREAM_COUNT: usize = 256;
 
 /// The client-side implementation of a webRTC connection channel.
 pub struct WebRTCClientChannel {
@@ -103,11 +106,9 @@ impl WebRTCClientChannel {
     }
 
     pub(crate) fn new_stream(&self) -> Result<Stream> {
-        // 256 is an arbitrarily high number for maximum concurrent streams, determined based on
-        // analogous value in goutils
-        if self.streams.len() >= 256 {
+        if self.streams.len() >= MAX_CONCURRENT_STREAM_COUNT {
             return Err(anyhow::anyhow!(
-                "Reached max concurrent stream cap of 256; unable to add new stream."
+                "Reached max concurrent stream cap of {MAX_CONCURRENT_STREAM_COUNT}; unable to add new stream."
             ));
         }
         let id = self.stream_id_counter.fetch_add(1, Ordering::AcqRel);

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -122,7 +122,7 @@ impl ViamChannel {
             response
         };
 
-        response.body(Body::from(body)).unwrap()
+        response.body(body).unwrap()
     }
 }
 

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -46,6 +46,7 @@ use tower_http::set_header::{SetRequestHeader, SetRequestHeaderLayer};
 // gRPC status codes
 const STATUS_CODE_OK: i32 = 0;
 const STATUS_CODE_UNKNOWN: i32 = 2;
+const STATUS_CODE_RESOURCE_EXHAUSTED: i32 = 8;
 
 type SecretType = String;
 
@@ -153,7 +154,7 @@ impl Service<http::Request<BoxBody>> for ViamChannel {
                         Err(e) => {
                             log::error!("{e}");
                             let response = response
-                                .header("grpc-status", &STATUS_CODE_UNKNOWN.to_string())
+                                .header("grpc-status", &STATUS_CODE_RESOURCE_EXHAUSTED.to_string())
                                 .body(Body::default())
                                 .unwrap();
 

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -163,51 +163,7 @@ impl Service<http::Request<BoxBody>> for ViamChannel {
                         }
                         Ok(stream) => {
                             Ok(Self::create_resp(&mut channel, stream, request, response).await)
-                        } // CR erodkin: clean up!
-                          //let stream_id = stream.id;
-                          //let metadata = Some(metadata_from_parts(&parts));
-                          //let headers = RequestHeaders {
-                          //method: parts
-                          //.uri
-                          //.path_and_query()
-                          //.map(PathAndQuery::to_string)
-                          //.unwrap_or_default(),
-                          //metadata,
-                          //timeout: None,
-                          //};
-
-                          //if let Err(e) = channel.write_headers(&stream, headers).await {
-                          //log::error!("error writing headers: {e}");
-                          //channel.close_stream_with_recv_error(stream_id, e);
-                          //status_code = STATUS_CODE_UNKNOWN;
-                          //}
-
-                          //let data = hyper::body::to_bytes(body).await.unwrap().to_vec();
-                          //if let Err(e) = channel.write_message(false, Some(stream), data).await {
-                          //log::error!("error sending message: {e}");
-                          //channel.close_stream_with_recv_error(stream_id, e);
-                          //status_code = STATUS_CODE_UNKNOWN;
-                          //};
-
-                          //let body = match channel.resp_body_from_stream(stream_id) {
-                          //Ok(body) => body,
-                          //Err(e) => {
-                          //log::error!("error receiving response from stream: {e}");
-                          //channel.close_stream_with_recv_error(stream_id, e);
-                          //status_code = STATUS_CODE_UNKNOWN;
-                          //Body::empty()
-                          //}
-                          //};
-
-                          //let response = if status_code != STATUS_CODE_OK {
-                          //response.header("grpc-status", &status_code.to_string())
-                          //} else {
-                          //response
-                          //};
-
-                          //let response = response.body(Body::from(body)).unwrap();
-                          //Ok(response)
-                          //}
+                        }
                     }
                 };
                 Box::pin(fut)

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -72,6 +72,60 @@ impl RPCCredentials {
     }
 }
 
+impl ViamChannel {
+    async fn create_resp(
+        channel: &mut Arc<WebRTCClientChannel>,
+        stream: crate::gen::proto::rpc::webrtc::v1::Stream,
+        request: http::Request<BoxBody>,
+        response: http::response::Builder,
+    ) -> http::Response<Body> {
+        let (parts, body) = request.into_parts();
+        let mut status_code = STATUS_CODE_OK;
+        let stream_id = stream.id;
+        let metadata = Some(metadata_from_parts(&parts));
+        let headers = RequestHeaders {
+            method: parts
+                .uri
+                .path_and_query()
+                .map(PathAndQuery::to_string)
+                .unwrap_or_default(),
+            metadata,
+            timeout: None,
+        };
+
+        if let Err(e) = channel.write_headers(&stream, headers).await {
+            log::error!("error writing headers: {e}");
+            channel.close_stream_with_recv_error(stream_id, e);
+            status_code = STATUS_CODE_UNKNOWN;
+        }
+
+        let data = hyper::body::to_bytes(body).await.unwrap().to_vec();
+        if let Err(e) = channel.write_message(false, Some(stream), data).await {
+            log::error!("error sending message: {e}");
+            channel.close_stream_with_recv_error(stream_id, e);
+            status_code = STATUS_CODE_UNKNOWN;
+        };
+
+        let body = match channel.resp_body_from_stream(stream_id) {
+            Ok(body) => body,
+            Err(e) => {
+                log::error!("error receiving response from stream: {e}");
+                channel.close_stream_with_recv_error(stream_id, e);
+                status_code = STATUS_CODE_UNKNOWN;
+                Body::empty()
+            }
+        };
+
+        let response = if status_code != STATUS_CODE_OK {
+            response.header("grpc-status", &status_code.to_string())
+        } else {
+            response
+        };
+
+        response.body(Body::from(body)).unwrap()
+    }
+}
+
 impl Service<http::Request<BoxBody>> for ViamChannel {
     type Response = http::Response<Body>;
     type Error = tonic::transport::Error;
@@ -88,60 +142,73 @@ impl Service<http::Request<BoxBody>> for ViamChannel {
         match self {
             Self::Direct(channel) => Box::pin(channel.call(request)),
             Self::WebRTC(channel) => {
-                let mut status_code = STATUS_CODE_OK;
-                let channel = channel.clone();
+                //let mut status_code = STATUS_CODE_OK;
+                let mut channel = channel.clone();
                 let fut = async move {
-                    let (parts, body) = request.into_parts();
-
-                    let stream = channel.new_stream();
-                    let stream_id = stream.id;
-                    let metadata = Some(metadata_from_parts(&parts));
-                    let headers = RequestHeaders {
-                        method: parts
-                            .uri
-                            .path_and_query()
-                            .map(PathAndQuery::to_string)
-                            .unwrap_or_default(),
-                        metadata,
-                        timeout: None,
-                    };
-
-                    if let Err(e) = channel.write_headers(&stream, headers).await {
-                        log::error!("error writing headers: {e}");
-                        channel.close_stream_with_recv_error(stream_id, e);
-                        status_code = STATUS_CODE_UNKNOWN;
-                    }
-
-                    let data = hyper::body::to_bytes(body).await.unwrap().to_vec();
-                    if let Err(e) = channel.write_message(false, Some(stream), data).await {
-                        log::error!("error sending message: {e}");
-                        channel.close_stream_with_recv_error(stream_id, e);
-                        status_code = STATUS_CODE_UNKNOWN;
-                    };
-
-                    let body = match channel.resp_body_from_stream(stream_id) {
-                        Ok(body) => body,
-                        Err(e) => {
-                            log::error!("error receiving response from stream: {e}");
-                            channel.close_stream_with_recv_error(stream_id, e);
-                            status_code = STATUS_CODE_UNKNOWN;
-                            Body::empty()
-                        }
-                    };
-
+                    //let (parts, body) = request.into_parts();
                     let response = http::response::Response::builder()
                         // standardized gRPC headers.
                         .header("content-type", "application/grpc")
                         .version(Version::HTTP_2);
 
-                    let response = if status_code != STATUS_CODE_OK {
-                        response.header("grpc-status", &status_code.to_string())
-                    } else {
-                        response
-                    };
+                    match channel.new_stream() {
+                        Err(e) => {
+                            log::error!("{e}");
+                            let response = response
+                                .header("grpc-status", &STATUS_CODE_UNKNOWN.to_string())
+                                .body(Body::default())
+                                .unwrap();
 
-                    let response = response.body(Body::from(body)).unwrap();
-                    Ok(response)
+                            Ok(response)
+                        }
+                        Ok(stream) => {
+                            Ok(Self::create_resp(&mut channel, stream, request, response).await)
+                        } // CR erodkin: clean up!
+                          //let stream_id = stream.id;
+                          //let metadata = Some(metadata_from_parts(&parts));
+                          //let headers = RequestHeaders {
+                          //method: parts
+                          //.uri
+                          //.path_and_query()
+                          //.map(PathAndQuery::to_string)
+                          //.unwrap_or_default(),
+                          //metadata,
+                          //timeout: None,
+                          //};
+
+                          //if let Err(e) = channel.write_headers(&stream, headers).await {
+                          //log::error!("error writing headers: {e}");
+                          //channel.close_stream_with_recv_error(stream_id, e);
+                          //status_code = STATUS_CODE_UNKNOWN;
+                          //}
+
+                          //let data = hyper::body::to_bytes(body).await.unwrap().to_vec();
+                          //if let Err(e) = channel.write_message(false, Some(stream), data).await {
+                          //log::error!("error sending message: {e}");
+                          //channel.close_stream_with_recv_error(stream_id, e);
+                          //status_code = STATUS_CODE_UNKNOWN;
+                          //};
+
+                          //let body = match channel.resp_body_from_stream(stream_id) {
+                          //Ok(body) => body,
+                          //Err(e) => {
+                          //log::error!("error receiving response from stream: {e}");
+                          //channel.close_stream_with_recv_error(stream_id, e);
+                          //status_code = STATUS_CODE_UNKNOWN;
+                          //Body::empty()
+                          //}
+                          //};
+
+                          //let response = if status_code != STATUS_CODE_OK {
+                          //response.header("grpc-status", &status_code.to_string())
+                          //} else {
+                          //response
+                          //};
+
+                          //let response = response.body(Body::from(body)).unwrap();
+                          //Ok(response)
+                          //}
+                    }
                 };
                 Box::pin(fut)
             }

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -142,10 +142,8 @@ impl Service<http::Request<BoxBody>> for ViamChannel {
         match self {
             Self::Direct(channel) => Box::pin(channel.call(request)),
             Self::WebRTC(channel) => {
-                //let mut status_code = STATUS_CODE_OK;
                 let mut channel = channel.clone();
                 let fut = async move {
-                    //let (parts, body) = request.into_parts();
                     let response = http::response::Response::builder()
                         // standardized gRPC headers.
                         .header("content-type", "application/grpc")


### PR DESCRIPTION
Updates us to webrtc v0.7.1, creates a blocking `close` fn for WebRTCBaseChannel to facilitate the upgrade.