### PR TITLE
prevent panic in `close_sync`

### DIFF
--- a/src/rpc/base_channel.rs
+++ b/src/rpc/base_channel.rs
@@ -81,6 +81,7 @@ impl WebRTCBaseChannel {
     /// Closes the channel
     #[allow(dead_code)]
     pub async fn close(&self) -> Result<()> {
+        log::debug!("Closing base channel");
         if self.closed.load(Ordering::Acquire) {
             return Ok(());
         }


### PR DESCRIPTION
In at least one known case (attempting to connect to a robot that is offline), `close_sync` panics when attempting to create a new thread. This PR causes to catch the panic and return it as an error instead.