### PR TITLE
RSDK-2407 - Fix gRPC error logging

### DIFF
--- a/src/rpc/client_channel.rs
+++ b/src/rpc/client_channel.rs
@@ -46,12 +46,6 @@ impl Debug for WebRTCClientChannel {
 
 impl Drop for WebRTCClientChannel {
     fn drop(&mut self) {
-        let bc = self.base_channel.clone();
-        if !bc.is_closed() {
-            if let Err(e) = bc.close_sync() {
-                log::error!("Error closing base channel: {e}")
-            }
-        };
         log::debug!("Dropping client channel {:?}", &self);
     }
 }

--- a/src/rpc/client_stream.rs
+++ b/src/rpc/client_stream.rs
@@ -70,7 +70,7 @@ impl WebRTCClientStream {
         };
 
         if let Some(e) = &err {
-            log::error!("received gRPC error: {e}");
+            log::debug!("received gRPC error: {e}");
         }
 
         self.base_stream.close_with_recv_error(&mut err.as_ref())

--- a/src/rpc/client_stream.rs
+++ b/src/rpc/client_stream.rs
@@ -70,7 +70,7 @@ impl WebRTCClientStream {
         };
 
         if let Some(e) = &err {
-            log::debug!("received gRPC error: {e}");
+            log::error!("received gRPC error: {e}");
         }
 
         self.base_stream.close_with_recv_error(&mut err.as_ref())


### PR DESCRIPTION
Major changes:
- When receiving gRPC errors, log but do not return as error (the error will still be received by users from the top level `call` function, but this avoids confusing errors that imply that any gRPC call error is a rust deserialization problem)
- Remove `close_sync` - this function was failing before because of issues creating runtimes within runtimes, which caused noisy and erroneous error messages to log when shutting down
- Add logging when dropping `WebRTCBaseChannel` to show that - despite removing the `close_sync` - we are in fact successfully dropping `WebRTCBaseChannel`s when done with them.