### PR TITLE
[RSDK-3103] TURN credentials are not broken

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,10 @@ tracing = {version = "0.1.34"}
 tracing-subscriber = {version = "0.3.11", features = ["env-filter"]}
 viam-mdns = "3.0.1"
 webpki-roots = "0.21.1"
-webrtc = "0.7.2"
+# TODO: We are using a commit hash to include a bug fix that has not yet been
+# released in a crate. Once the new crate is released, please use that instead
+# of the git revision below. As of this comment the latest version is `0.7.2`.
+webrtc = { git = "https://github.com/webrtc-rs/webrtc.git", rev = "5aa49c03a183a610b44fe01e9531508e4fddecb1" }
 
 [dev-dependencies]
 async-stream = "0.3.3"

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -6,7 +6,7 @@ use crate::gen::google;
 use crate::gen::proto::rpc::webrtc::v1::{
     call_response::Stage, call_update_request::Update,
     signaling_service_client::SignalingServiceClient, CallUpdateRequest,
-    OptionalWebRtcConfigRequest,
+    OptionalWebRtcConfigRequest, OptionalWebRtcConfigResponse
 };
 use crate::gen::proto::rpc::webrtc::v1::{
     CallRequest, IceCandidate, Metadata, RequestHeaders, Strings,
@@ -752,6 +752,9 @@ async fn maybe_connect_via_webrtc(
     {
         Ok(resp) => resp,
         Err(e) => {
+            if e.code() == tonic::Code::Unimplemented {
+                OptionalWebRtcConfigResponse::default();
+            }
             return Err(anyhow::anyhow!(e));
         }
     };


### PR DESCRIPTION
@edaniels This includes the fix for signaling where it can come back unimplemented 