### PR TITLE
RSDK-3150 - fix ice server credential type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,7 @@ tracing = {version = "0.1.34"}
 tracing-subscriber = {version = "0.3.11", features = ["env-filter"]}
 viam-mdns = "3.0.1"
 webpki-roots = "0.21.1"
-# TODO: We are using a commit hash to include a bug fix that has not yet been
-# released in a crate. Once the new crate is released, please use that instead
-# of the git revision below. As of this comment the latest version is `0.7.2`.
-webrtc = { git = "https://github.com/webrtc-rs/webrtc.git", rev = "5aa49c03a183a610b44fe01e9531508e4fddecb1" }
+webrtc = "0.7.3"
 
 [dev-dependencies]
 async-stream = "0.3.3"

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -6,7 +6,7 @@ use crate::gen::google;
 use crate::gen::proto::rpc::webrtc::v1::{
     call_response::Stage, call_update_request::Update,
     signaling_service_client::SignalingServiceClient, CallUpdateRequest,
-    OptionalWebRtcConfigRequest, OptionalWebRtcConfigResponse
+    OptionalWebRtcConfigRequest, OptionalWebRtcConfigResponse,
 };
 use crate::gen::proto::rpc::webrtc::v1::{
     CallRequest, IceCandidate, Metadata, RequestHeaders, Strings,

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -753,9 +753,10 @@ async fn maybe_connect_via_webrtc(
         Ok(resp) => resp,
         Err(e) => {
             if e.code() == tonic::Code::Unimplemented {
-                OptionalWebRtcConfigResponse::default();
+                tonic::Response::new(OptionalWebRtcConfigResponse::default())
+            } else {
+                return Err(anyhow::anyhow!(e));
             }
-            return Err(anyhow::anyhow!(e));
         }
     };
 

--- a/src/rpc/webrtc.rs
+++ b/src/rpc/webrtc.rs
@@ -147,7 +147,7 @@ fn ice_server_from_proto(ice_server: IceServer) -> RTCIceServer {
         urls: ice_server.urls,
         username: ice_server.username,
         credential: ice_server.credential,
-        ..Default::default()
+        credential_type: webrtc::ice_transport::ice_credential_type::RTCIceCredentialType::Password,
     }
 }
 


### PR DESCRIPTION
When the webrtc crate updated to using `#[default]` instead of manually defining, a couple types had their defaults changed. One of these changes was causing stun credential failures. This updates so we no longer rely on the default.