### PR TITLE
[RSDK-3115] Rust + amazonlinux2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,8 @@ jobs:
       - name: Setup rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source "$HOME/.cargo/env"
+          rustup target add ${{ matrix.target }}
       - name: Setup build directory
         run: mkdir builds
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup rust toolchain
+        shell: bash
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           source "$HOME/.cargo/env"
@@ -82,6 +83,7 @@ jobs:
       - name: Setup build directory
         run: mkdir builds
       - name: Build
+        shell: bash
         run: |
           source "$HOME/.cargo/env"
           cargo build --release --target=${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,36 +23,36 @@ jobs:
         if: |
           steps.is_organization_member.outputs.result == 'false'
 
-  # build_macos:
-  #   if: github.repository_owner == 'viamrobotics'
-  #   runs-on: [self-hosted, ARM64, macOS]
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - target: aarch64-apple-darwin
-  #           platform: macosx_arm64
-  #         - target: x86_64-apple-darwin
-  #           platform: macosx_x86_64
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Setup rust toolchain
-  #       uses: dtolnay/rust-toolchain@stable
-  #       with:
-  #         toolchain: stable
-  #         targets: ${{ matrix.target }}
-  #     - name: Setup build directory
-  #       run: mkdir builds
-  #     - name: Build
-  #       run: |
-  #         cargo build --release --target=${{ matrix.target }}
-  #     - name: Copy
-  #       run: cp target/${{ matrix.target }}/release/libviam_rust_utils.dylib builds/libviam_rust_utils-${{ matrix.platform }}.dylib
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: builds
-  #         path: builds
+  build_macos:
+    if: github.repository_owner == 'viamrobotics'
+    runs-on: [self-hosted, ARM64, macOS]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            platform: macosx_arm64
+          - target: x86_64-apple-darwin
+            platform: macosx_x86_64
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+      - name: Setup build directory
+        run: mkdir builds
+      - name: Build
+        run: |
+          cargo build --release --target=${{ matrix.target }}
+      - name: Copy
+        run: cp target/${{ matrix.target }}/release/libviam_rust_utils.dylib builds/libviam_rust_utils-${{ matrix.platform }}.dylib
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: builds
+          path: builds
 
   build_linux:
     if: github.repository_owner == 'viamrobotics'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: aarch64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-gnu:centos
             platform: linux_aarch64
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-gnu:centos
             platform: linux_x86_64
           - target: arm-unknown-linux-gnueabihf
             platform: linux_armv6l

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,17 +37,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
       - name: Setup build directory
         run: mkdir builds
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --target=${{ matrix.target }}
+        run: |
+          cargo build --release --target=${{ matrix.target }}
       - name: Copy
         run: cp target/${{ matrix.target }}/release/libviam_rust_utils.dylib builds/libviam_rust_utils-${{ matrix.platform }}.dylib
       - name: Upload artifacts
@@ -68,29 +66,23 @@ jobs:
         include:
           - target: aarch64-unknown-linux-gnu
             platform: linux_aarch64
-            cross: true
           - target: x86_64-unknown-linux-gnu
             platform: linux_x86_64
-            cross: true
           - target: arm-unknown-linux-gnueabihf
             platform: linux_armv6l
-            cross: true
     steps:
       - uses: actions/checkout@v3
       - name: Setup rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
+          components: cross
       - name: Setup build directory
         run: mkdir builds
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --target=${{ matrix.target }}
-          use-cross: ${{ matrix.cross }}
+        run: |
+          cross build --release --target=${{ matrix.target }}
         env:
           CROSS_CONTAINER_IN_CONTAINER: ${{ matrix.cross }}
       - name: Copy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,6 @@ jobs:
     runs-on: [self-hosted, x64]
     container:
       image: ghcr.io/cross-rs/${{ matrix.image }}
-      options: -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/project -w /project
     strategy:
       fail-fast: false
       matrix:
@@ -76,20 +75,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          targets: ${{ matrix.target }}
-      - name: Setup cross compiler
         run: |
-          cargo install cross --git https://github.com/cross-rs/cross
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source "$HOME/.cargo/env"
       - name: Setup build directory
         run: mkdir builds
       - name: Build
         run: |
-          cross build --release --target=${{ matrix.cross }}
-        env:
-          CROSS_CONTAINER_IN_CONTAINER: true
+          cargo build --release --target=${{ matrix.target }}
       - name: Copy
         run: cp target/${{ matrix.target }}/release/libviam_rust_utils.so builds/libviam_rust_utils-${{ matrix.platform }}.so
       - name: Upload artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,7 @@ jobs:
     if: github.repository_owner == 'viamrobotics'
     runs-on: [self-hosted, x64]
     container:
-      image: ghcr.io/viamrobotics/canon:amd64-cache
-      options: -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/project -w /project -e CROSS_CONTAINER_IN_CONTAINER=true
+      image: ghcr.io/cross-rs/${{ matrix.target }}
     strategy:
       fail-fast: false
       matrix:
@@ -77,16 +76,13 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
-      - name: Setup cross compiler
-        run: |
-          cargo install cross --git https://github.com/cross-rs/cross
       - name: Setup build directory
         run: mkdir builds
       - name: Build
         run: |
-          cross build --release --target=${{ matrix.target }}
-        env:
-          CROSS_CONTAINER_IN_CONTAINER: ${{ matrix.cross }}
+          cargo build --release --target=${{ matrix.target }}
+        # env:
+          # CROSS_CONTAINER_IN_CONTAINER: true
       - name: Copy
         run: cp target/${{ matrix.target }}/release/libviam_rust_utils.so builds/libviam_rust_utils-${{ matrix.platform }}.so
       - name: Upload artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
     if: github.repository_owner == 'viamrobotics'
     runs-on: [self-hosted, x64]
     container:
-      image: quay.io/pypa/manylinux2014_x86_64
+      image: ghcr.io/viamrobotics/canon:amd64-cache
       options: -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/project -w /project
     strategy:
       fail-fast: false
@@ -71,7 +71,7 @@ jobs:
             cross: true
           - target: x86_64-unknown-linux-gnu
             platform: linux_x86_64
-            cross: false
+            cross: true
           - target: arm-unknown-linux-gnueabihf
             platform: linux_armv6l
             cross: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,11 +75,11 @@ jobs:
             image: arm-unknown-linux-gnueabihf:main
     steps:
       - uses: actions/checkout@v3
-      # - name: Setup rust toolchain
-      #   uses: dtolnay/rust-toolchain@stable
-      #   with:
-      #     toolchain: stable
-      #     targets: ${{ matrix.target }}
+      - name: Setup rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
       - name: Setup cross compiler
         run: |
           cargo install cross --git https://github.com/cross-rs/cross

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,10 +64,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: aarch64-unknown-linux-gnu:centos
+          - target: aarch64-unknown-linux-gnu
             platform: linux_aarch64
-          - target: x86_64-unknown-linux-gnu:centos
+            cross: aarch64-unknown-linux-gnu:centos
+          - target: x86_64-unknown-linux-gnu
             platform: linux_x86_64
+            cross: x86_64-unknown-linux-gnu:centos
           - target: arm-unknown-linux-gnueabihf
             platform: linux_armv6l
     steps:
@@ -84,7 +86,7 @@ jobs:
         run: mkdir builds
       - name: Build
         run: |
-          cross build --release --target=${{ matrix.target }}
+          cross build --release --target=${{ matrix.cross }}
         env:
           CROSS_CONTAINER_IN_CONTAINER: true
       - name: Copy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: [self-hosted, x64]
     container:
       image: ghcr.io/viamrobotics/canon:amd64-cache
-      options: -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/project -w /project
+      options: -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/project -w /project -e CROSS_CONTAINER_IN_CONTAINER=true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,9 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
-          components: cross
+      - name: Setup cross compiler
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross
       - name: Setup build directory
         run: mkdir builds
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,8 @@ jobs:
     if: github.repository_owner == 'viamrobotics'
     runs-on: [self-hosted, x64]
     container:
-      image: ghcr.io/cross-rs/${{ matrix.target }}
+      image: ghcr.io/viamrobotics/canon:amd64-cache
+      options: -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/project -w /project
     strategy:
       fail-fast: false
       matrix:
@@ -76,13 +77,16 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
+      - name: Setup cross compiler
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross
       - name: Setup build directory
         run: mkdir builds
       - name: Build
         run: |
-          cargo build --release --target=${{ matrix.target }}
-        # env:
-          # CROSS_CONTAINER_IN_CONTAINER: true
+          cross build --release --target=${{ matrix.target }}
+        env:
+          CROSS_CONTAINER_IN_CONTAINER: true
       - name: Copy
         run: cp target/${{ matrix.target }}/release/libviam_rust_utils.so builds/libviam_rust_utils-${{ matrix.platform }}.so
       - name: Upload artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,11 +77,11 @@ jobs:
       - name: Setup rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          source "$HOME/.cargo/env"
       - name: Setup build directory
         run: mkdir builds
       - name: Build
         run: |
+          source "$HOME/.cargo/env"
           cargo build --release --target=${{ matrix.target }}
       - name: Copy
         run: cp target/${{ matrix.target }}/release/libviam_rust_utils.so builds/libviam_rust_utils-${{ matrix.platform }}.so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,42 +23,42 @@ jobs:
         if: |
           steps.is_organization_member.outputs.result == 'false'
 
-  build_macos:
-    if: github.repository_owner == 'viamrobotics'
-    runs-on: [self-hosted, ARM64, macOS]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: aarch64-apple-darwin
-            platform: macosx_arm64
-          - target: x86_64-apple-darwin
-            platform: macosx_x86_64
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          targets: ${{ matrix.target }}
-      - name: Setup build directory
-        run: mkdir builds
-      - name: Build
-        run: |
-          cargo build --release --target=${{ matrix.target }}
-      - name: Copy
-        run: cp target/${{ matrix.target }}/release/libviam_rust_utils.dylib builds/libviam_rust_utils-${{ matrix.platform }}.dylib
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: builds
-          path: builds
+  # build_macos:
+  #   if: github.repository_owner == 'viamrobotics'
+  #   runs-on: [self-hosted, ARM64, macOS]
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - target: aarch64-apple-darwin
+  #           platform: macosx_arm64
+  #         - target: x86_64-apple-darwin
+  #           platform: macosx_x86_64
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Setup rust toolchain
+  #       uses: dtolnay/rust-toolchain@stable
+  #       with:
+  #         toolchain: stable
+  #         targets: ${{ matrix.target }}
+  #     - name: Setup build directory
+  #       run: mkdir builds
+  #     - name: Build
+  #       run: |
+  #         cargo build --release --target=${{ matrix.target }}
+  #     - name: Copy
+  #       run: cp target/${{ matrix.target }}/release/libviam_rust_utils.dylib builds/libviam_rust_utils-${{ matrix.platform }}.dylib
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: builds
+  #         path: builds
 
   build_linux:
     if: github.repository_owner == 'viamrobotics'
     runs-on: [self-hosted, x64]
     container:
-      image: ghcr.io/viamrobotics/canon:amd64-cache
+      image: ghcr.io/cross-rs/${{ matrix.image }}
       options: -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/project -w /project
     strategy:
       fail-fast: false
@@ -66,19 +66,20 @@ jobs:
         include:
           - target: aarch64-unknown-linux-gnu
             platform: linux_aarch64
-            cross: aarch64-unknown-linux-gnu:centos
+            image: aarch64-unknown-linux-gnu:main-centos
           - target: x86_64-unknown-linux-gnu
             platform: linux_x86_64
-            cross: x86_64-unknown-linux-gnu:centos
+            image: x86_64-unknown-linux-gnu:main-centos
           - target: arm-unknown-linux-gnueabihf
             platform: linux_armv6l
+            image: arm-unknown-linux-gnueabihf:main
     steps:
       - uses: actions/checkout@v3
-      - name: Setup rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          targets: ${{ matrix.target }}
+      # - name: Setup rust toolchain
+      #   uses: dtolnay/rust-toolchain@stable
+      #   with:
+      #     toolchain: stable
+      #     targets: ${{ matrix.target }}
       - name: Setup cross compiler
         run: |
           cargo install cross --git https://github.com/cross-rs/cross

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: andymckay/cancel-action@0.2
         if: |
           steps.is_organization_member.outputs.result == 'false'
-          
+
   build_macos:
     if: github.repository_owner == 'viamrobotics'
     runs-on: [self-hosted, ARM64, macOS]
@@ -60,7 +60,7 @@ jobs:
     if: github.repository_owner == 'viamrobotics'
     runs-on: [self-hosted, x64]
     container:
-      image: ghcr.io/viamrobotics/canon:amd64-cache
+      image: quay.io/pypa/manylinux2014_x86_64
       options: -v /var/run/docker.sock:/var/run/docker.sock -v ${{ github.workspace }}:/project -w /project
     strategy:
       fail-fast: false


### PR DESCRIPTION
amazonlinux2 (the default for AWS lambdas) has `glibc == 2.26`. Our release workflow was building using `glibc == 2.28`. So, I decided to use a different set of containers with a lower glibc version.

But then, it turns out our `actions-rs` actions for installing the rust toolchain and cargo were no longer supported, and causing deprecation warnings in github actions. So I updated those too. 

But then the upgraded version didn't include `cross` -- a tool for cross compiling rust libraries. The way `cross` works is by using docker containers to compile against that architecture. So I changed the container images again, this time to what `cross` was using for each of our supported platforms.

But then those images don't come with `rust` installed -- they use the host's `rust`. Well then I had to install `rust` as well.

But then the new `install rust toolchain` action was using a version of `curl` that was too advanced for the now old images. So now I install rust from source.

SO ALL IN ALL:
we now compile using `glibc == 2.17` for linux and i believe everything works as it should. 