### PR TITLE
RSDK-3383 - Workflow updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Setup rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: stable
+          toolchain: stable
 
       - name: Publish
       - uses: katyo/publish-crates@v2
         with:
-            registry-token: ${{ secrets.CRATES_API_TOKEN }}
-            dry-run: true
+          registry-token: ${{ secrets.CRATES_API_TOKEN }}
+          dry-run: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
           toolchain: stable
 
       - name: Publish
-      - uses: katyo/publish-crates@v2
+        uses: katyo/publish-crates@v2
         with:
           registry-token: ${{ secrets.CRATES_API_TOKEN }}
           dry-run: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,4 +37,3 @@ jobs:
         uses: katyo/publish-crates@v2
         with:
           registry-token: ${{ secrets.CRATES_API_TOKEN }}
-          dry-run: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,3 +26,15 @@ jobs:
         if: |
           github.event_name == 'workflow_dispatch' && steps.is_organization_member.outputs.result == 'false'
 
+      - uses: actions/checkout@v3
+
+      - name: Setup rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+
+      - name: Publish
+      - uses: katyo/publish-crates@v2
+        with:
+            registry-token: ${{ secrets.CRATES_API_TOKEN }}
+            dry-run: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Build + draft release
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       image: ghcr.io/viamrobotics/canon:amd64
     outputs:
       version: ${{ steps.which_version.outputs.version }}
+      sha: ${{ steps.commit.outputs.commit_long_sha }}
     steps:
       - name: Check if organization member
         id: is_organization_member
@@ -89,7 +90,10 @@ jobs:
           - target: x86_64-apple-darwin
             platform: macosx_x86_64
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
       - name: Setup rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -128,7 +132,10 @@ jobs:
             platform: linux_armv6l
             image: arm-unknown-linux-gnueabihf:main
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
       - name: Setup rust toolchain
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
 
   release:
     needs: [prepare, build_macos, build_linux]
-    if: github.repository_owner == 'viamrobotics')
+    if: github.repository_owner == 'viamrobotics'
     runs-on: [self-hosted, x64]
     container:
       image: ghcr.io/viamrobotics/canon:amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,25 @@ name: Build release binaries
 
 on:
   workflow_dispatch:
-
+    inputs:
+      version:
+        description: 'The type of version bump. Use "nobump" for no change.'
+        type: choice
+        required: true
+        default: nobump
+        options:
+        - major
+        - minor
+        - patch
+        - nobump
 jobs:
-  check_if_org_member:
+  prepare:
     if: github.repository_owner == 'viamrobotics'
     runs-on: [self-hosted, x64]
     container:
       image: ghcr.io/viamrobotics/canon:amd64
+    outputs:
+      version: ${{ steps.which_version.outputs.version }}
     steps:
       - name: Check if organization member
         id: is_organization_member
@@ -18,13 +30,55 @@ jobs:
           username: ${{ github.actor }}
           token:  ${{ secrets.GITHUB_TOKEN }}
 
-      - name: cancelling
+      - name: Cancelling - user not part of organization
         uses: andymckay/cancel-action@0.2
         if: |
           steps.is_organization_member.outputs.result == 'false'
 
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Setup rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Bump Version
+        shell: bash
+        if: inputs.version != 'nobump'
+        run: |
+          cargo install cargo-bump
+          cargo bump ${{ inputs.version }}
+
+      - name: Which Version
+        id: which_version
+        shell: bash
+        run: |
+          echo "version=$(cargo pkgid | sed 's/.*@//g')" >> $GITHUB_OUTPUT
+
+      - name: Check if release exists
+        uses: cardinalby/git-get-release-action@1.2.4
+        id: release_exists
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          releaseName: v${{ steps.which_version.outputs.version }}
+          doNotFailIfNotFound: 'true'
+
+      - name: Cancelling - release already exists
+        uses: andymckay/cancel-action@0.2
+        if: steps.release_exists.outputs.id != ''
+
+      - name: Commit + Push
+        id: commit
+        uses: EndBug/add-and-commit@v9.0.0
+        with:
+          default_author: github_actions
+          message: Bumping version to v${{ steps.which_version.outputs.version }} [skip ci]
+
   build_macos:
     if: github.repository_owner == 'viamrobotics'
+    needs: [prepare]
     runs-on: [self-hosted, ARM64, macOS]
     strategy:
       fail-fast: false
@@ -56,6 +110,7 @@ jobs:
 
   build_linux:
     if: github.repository_owner == 'viamrobotics'
+    needs: [prepare]
     runs-on: [self-hosted, x64]
     container:
       image: ghcr.io/cross-rs/${{ matrix.image }}
@@ -94,3 +149,22 @@ jobs:
         with:
           name: builds
           path: builds
+
+  release:
+    needs: [prepare, build_macos, build_linux]
+    if: github.repository_owner == 'viamrobotics')
+    runs-on: [self-hosted, x64]
+    container:
+      image: ghcr.io/viamrobotics/canon:amd64
+
+    steps:
+      - uses: actions/download-artifact@v3
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ needs.prepare.outputs.version }}
+          files: builds/*
+          draft: true
+          prerelease: false
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
         id: which_version
         shell: bash
         run: |
+          cargo update
           echo "version=$(cargo pkgid | sed 's/.*@//g')" >> $GITHUB_OUTPUT
 
       - name: Check if release exists

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build release binaries
+name: Release
 
 on:
   workflow_dispatch:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "viam-rust-utils"
-version = "0.0.21"
+version = "0.0.20"
 edition = "2021"
 license = "Apache-2.0"
 description = "Utilities designed for use with Viamrobotics's SDKs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "viam-rust-utils"
-version = "0.0.20"
+version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Utilities designed for use with Viamrobotics's SDKs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "viam-rust-utils"
-version = "0.1.0"
+version = "0.0.20"
 edition = "2021"
 license = "Apache-2.0"
 description = "Utilities designed for use with Viamrobotics's SDKs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "viam-rust-utils"
-version = "0.0.20"
+version = "0.0.21"
 edition = "2021"
 license = "Apache-2.0"
 description = "Utilities designed for use with Viamrobotics's SDKs"


### PR DESCRIPTION
this creates the a draft release from the release action with an automated version bump. The builds are automatically populated as well
adds publish action to publish to crates

tested all the way up to actually publishing (able to run it with `--dry-run` with no issues tho)

basically follows the structure of the python workflows before we revamped it