### PR TITLE
RSDK-3833 Dial takes type and payload as parameters

### DIFF
--- a/examples/src/ffi/cpp/ffi_echo.cc
+++ b/examples/src/ffi/cpp/ffi_echo.cc
@@ -19,7 +19,7 @@ using proto::rpc::examples::echo::v1::EchoService;
 extern "C" void *init_rust_runtime();
 extern "C" int free_rust_runtime(void *ptr);
 extern "C" void free_string(char* s);
-extern "C" char *dial(const char *uri, const char *payload,
+extern "C" char *dial(const char *uri, const char *r#type, const char *payload,
                              bool allow_insecure, void *ptr);
 
 class EchoServiceClient {

--- a/examples/src/ffi/cpp/ffi_robot.cc
+++ b/examples/src/ffi/cpp/ffi_robot.cc
@@ -19,7 +19,7 @@ using viam::robot::v1::ResourceNamesResponse;
 extern "C" void *init_rust_runtime();
 extern "C" int free_rust_runtime(void *ptr);
 extern "C" void free_string(char* s);
-extern "C" char *dial(const char *uri, const char *payload,
+extern "C" char *dial(const char *uri, const char *r#type, const char *payload,
                              bool allow_insecure, void *ptr);
 
 class RobotServiceClient {
@@ -51,7 +51,7 @@ private:
 int main(int argc, char *argv[]) {
 
   void *ptr = init_rust_runtime();
-  char *path = dial("<your robot's uri>", "<your robot's credentials>", false, ptr);
+  char *path = dial("<your robot's uri>", "<your robot's payload>", "<your robot's type>", false, ptr);
   if(path == NULL){
 	  free_rust_runtime(ptr);
 	  return 1;


### PR DESCRIPTION
Credential type is currently hard-coded as robot-location-secret, but we’re starting to also use robot-secret. In order to pass type as a parameter in the cpp-sdk we need to update the dial function in rust-utils to account for the new argument also.

