### PR TITLE
RSDK-4035 - add loopback, webrtc connection fallback for dialdbg

### DIFF
--- a/dialdbg/src/main.rs
+++ b/dialdbg/src/main.rs
@@ -143,7 +143,8 @@ async fn all_mdns_addresses() -> Result<HashSet<String>> {
     // The 250ms query interval and 1500ms timeout here are meant to mimic the mDNS query
     // timeouts that dial itself used.
     let stream =
-        viam_mdns::discover::all(VIAM_MDNS_SERVICE_NAME, Duration::from_millis(250))?.listen();
+        viam_mdns::discover::all_with_loopback(VIAM_MDNS_SERVICE_NAME, Duration::from_millis(250))?
+            .listen();
     let waiter = tokio::time::sleep(Duration::from_millis(1500));
 
     pin_mut!(stream);

--- a/src/rpc/log_prefixes.rs
+++ b/src/rpc/log_prefixes.rs
@@ -13,3 +13,7 @@ pub const DIALED_GRPC: &'static str = "Connected via gRPC";
 pub const DIALED_WEBRTC: &'static str = "Connected via WebRTC";
 
 pub const CANDIDATE_SELECTED: &'static str = "Selected candidate pair";
+
+// `_EXTERN` because we do not have ownership of this message; matching on it should only
+// ever be used as a fallback.
+pub const ICE_CONNECTED_EXTERN: &'static str = "ICE connection state changed: connected";


### PR DESCRIPTION
#### Major Changes
- When mDNS fails, add loopback support to the `dialdbg` mDNS logging query.
- When parsing logs, consider successful ICE connection to be evidence of webRTC connection to circumvent flaky log issues (to be diagnosed/solved in a subsequent ticket)
