### PR TITLE
update buf gen

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -4,3 +4,5 @@ plugins:
     out: src/gen/
   - plugin: buf.build/community/neoeinstein-tonic:v0.3.0
     out: src/gen/
+    opt:
+        - no_include=true

--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -3,22 +3,26 @@ pub mod proto {
         pub mod webrtc {
             pub mod v1 {
                 include!("proto.rpc.webrtc.v1.rs");
+                include!("proto.rpc.webrtc.v1.tonic.rs");
             }
         }
         pub mod examples {
             pub mod echo {
                 pub mod v1 {
                     include!("proto.rpc.examples.echo.v1.rs");
+                    include!("proto.rpc.examples.echo.v1.tonic.rs");
                 }
             }
             pub mod echoresource {
                 pub mod v1 {
                     include!("proto.rpc.examples.echoresource.v1.rs");
+                    include!("proto.rpc.examples.echoresource.v1.tonic.rs");
                 }
             }
         }
         pub mod v1 {
             include!("proto.rpc.v1.rs");
+            include!("proto.rpc.v1.tonic.rs");
         }
     }
 }

--- a/src/gen/proto.rpc.examples.echo.v1.rs
+++ b/src/gen/proto.rpc.examples.echo.v1.rs
@@ -35,5 +35,4 @@ pub struct EchoBiDiResponse {
     #[prost(string, tag="1")]
     pub message: ::prost::alloc::string::String,
 }
-include!("proto.rpc.examples.echo.v1.tonic.rs");
 // @@protoc_insertion_point(module)

--- a/src/gen/proto.rpc.examples.echoresource.v1.rs
+++ b/src/gen/proto.rpc.examples.echoresource.v1.rs
@@ -41,5 +41,4 @@ pub struct EchoResourceBiDiResponse {
     #[prost(string, tag="1")]
     pub message: ::prost::alloc::string::String,
 }
-include!("proto.rpc.examples.echoresource.v1.tonic.rs");
 // @@protoc_insertion_point(module)

--- a/src/gen/proto.rpc.examples.fileupload.v1.rs
+++ b/src/gen/proto.rpc.examples.fileupload.v1.rs
@@ -24,5 +24,4 @@ pub struct UploadFileResponse {
     #[prost(int64, tag="2")]
     pub size: i64,
 }
-include!("proto.rpc.examples.fileupload.v1.tonic.rs");
 // @@protoc_insertion_point(module)

--- a/src/gen/proto.rpc.v1.rs
+++ b/src/gen/proto.rpc.v1.rs
@@ -47,5 +47,4 @@ pub struct AuthenticateToResponse {
     #[prost(string, tag="1")]
     pub access_token: ::prost::alloc::string::String,
 }
-include!("proto.rpc.v1.tonic.rs");
 // @@protoc_insertion_point(module)

--- a/src/gen/proto.rpc.webrtc.v1.rs
+++ b/src/gen/proto.rpc.webrtc.v1.rs
@@ -367,5 +367,4 @@ pub struct OptionalWebRtcConfigResponse {
     #[prost(message, optional, tag="1")]
     pub config: ::core::option::Option<WebRtcConfig>,
 }
-include!("proto.rpc.webrtc.v1.tonic.rs");
 // @@protoc_insertion_point(module)


### PR DESCRIPTION
With the most recent update to the tonic code generating plugin we are not able to compile the Generic component int he viam-rust-sdk. There is a workaround where instead on including the prost type file into the tonic generated tonic service we keep them separate. This slightly changes the types so we also have to update the rust-utils crate with this update so viam-rust-sdk can use it.