### PR TITLE
RDSK-3444 Add basic RTT measuring to dialdbg

### DIFF
--- a/dialdbg/src/main.rs
+++ b/dialdbg/src/main.rs
@@ -205,7 +205,7 @@ async fn main() -> Result<()> {
 
         if let Some(ch) = ch {
             if !args.nortt {
-                let average_rtt = rtt::measure_rtt(ch.clone(), 10).await?;
+                let average_rtt = rtt::measure_rtt(ch, 10).await?;
                 writeln!(
                     out,
                     "average RTT across established gRPC connection: {}ms",

--- a/dialdbg/src/main.rs
+++ b/dialdbg/src/main.rs
@@ -205,10 +205,11 @@ async fn main() -> Result<()> {
 
         if let Some(ch) = ch {
             if !args.nortt {
-                let average_rtt = rtt::measure_rtt(ch.clone(), 5).await?;
+                let average_rtt = rtt::measure_rtt(ch.clone(), 10).await?;
                 writeln!(
                     out,
-                    "average RTT across established gRPC connection: {average_rtt}"
+                    "average RTT across established gRPC connection: {}ms",
+                    average_rtt.as_millis()
                 )?;
             }
         }
@@ -253,10 +254,11 @@ async fn main() -> Result<()> {
 
         if let Some(ch) = ch {
             if !args.nortt {
-                let average_rtt = rtt::measure_rtt(ch.clone(), 5).await?;
+                let average_rtt = rtt::measure_rtt(ch.clone(), 10).await?;
                 writeln!(
                     out,
-                    "average RTT across established WebRTC connection: {average_rtt}"
+                    "average RTT across established WebRTC connection: {}ms",
+                    average_rtt.as_millis()
                 )?;
             }
 

--- a/dialdbg/src/rtt.rs
+++ b/dialdbg/src/rtt.rs
@@ -1,0 +1,7 @@
+use anyhow::Result;
+use viam::rpc::dial::ViamChannel;
+
+// Returns the average round-trip-time over num_pings for the passed-in channel.
+pub(crate) async fn measure_rtt(_ch: ViamChannel, _num_pings: usize) -> Result<f64> {
+    Ok(0.0)
+}

--- a/dialdbg/src/rtt.rs
+++ b/dialdbg/src/rtt.rs
@@ -1,7 +1,28 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use std::{ops::Add, time};
+use viam::gen::proto::rpc::examples::echo::v1::{
+    echo_service_client::EchoServiceClient, EchoRequest,
+};
 use viam::rpc::dial::ViamChannel;
 
 // Returns the average round-trip-time over num_pings for the passed-in channel.
-pub(crate) async fn measure_rtt(_ch: ViamChannel, _num_pings: usize) -> Result<f64> {
-    Ok(0.0)
+pub(crate) async fn measure_rtt(ch: ViamChannel, num_pings: u32) -> Result<time::Duration> {
+    let mut total_ping = time::Duration::new(0, 0);
+    for _ in 0..num_pings {
+        let start = time::Instant::now();
+
+        // Send an echo request across the channel. It's unlikely the remote will be able to
+        // respond to this request, but we'll still get a good sense of RTT.
+        let mut service = EchoServiceClient::new(ch.clone());
+        let echo_request = EchoRequest {
+            message: "dialdbg".to_string(),
+        };
+        service.echo(echo_request).await.ok();
+
+        total_ping = total_ping.add(time::Instant::now().duration_since(start));
+    }
+    if let Some(avg_ping) = total_ping.checked_div(num_pings) {
+        return Ok(avg_ping);
+    }
+    Err(anyhow!("cannot divide by zero"))
 }


### PR DESCRIPTION
[RSDK-3444](https://viam.atlassian.net/browse/RSDK-3444)

Adds basic RTT measuring to `dialdbg` (can be disabled with `--nortt`. When a connection is successfully established; 10 echo requests will be run using the created channel, and the average RTT will be printed as:

```
average RTT across established [type of connection] connection: 149ms
```

[RSDK-3444]: https://viam.atlassian.net/browse/RSDK-3444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ