### PR TITLE
RSDK-3446 Add build-dialdbg makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ build:
 	cargo build
 build-example:
 	cd examples/ && cargo build
+build-dialdbg:
+	cd dialdbg/ && cargo build
 buf-clean:
 	find src/gen -type f \( -iname "*.rs" ! -iname "mod.rs" \) -delete
 buf-install:


### PR DESCRIPTION
RSDK-3446

Adds `build-dialdbg` makefile target.