### PR TITLE
Remove erroneous --features option for cargo release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,7 @@ jobs:
         if: inputs.version != 'nobump'
         run: |
           cargo install cargo-release
-          # Include dialdbg feature to publish dialdbg. Users can later use 
-          # `cargo add viam-rust-utils --features dialdbg` if they want access
-          # to dialdbg for some reason.
-          cargo release version ${{ inputs.version }} --features dialdbg --execute --no-confirm
+          cargo release version ${{ inputs.version }} --execute --no-confirm
 
       - name: Which Version
         id: which_version


### PR DESCRIPTION
Removes `--features` flag that attempted to include `dialdbg` feature during cargo release. 

`--features` is actually a flag for [`cargo publish`](https://doc.rust-lang.org/cargo/commands/cargo-publish.html#feature-selection), which we do not use in our workflows (we use a GH action to publish the crate). Upon reflection, I actually think we _don't_ want to include the `dialdbg` features in our crates.io publication. We _just_ want the home-brew formula to be able to build the crate with the feature enabled and extract the binary. Let me know if you disagree.