### PR TITLE
RSDK-4297 Include local session description in dialdbg

### DIFF
--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -870,6 +870,15 @@ async fn maybe_connect_via_webrtc(
     }
 
     let local_description = peer_connection.local_description().await.unwrap();
+
+    // Local SD will be multi-line, so use two log messages to indicate start, SD and end.
+    log::debug!(
+        "{}\n{}",
+        log_prefixes::START_LOCAL_SESSION_DESCRIPTION,
+        local_description.sdp
+    );
+    log::debug!("{}", log_prefixes::END_LOCAL_SESSION_DESCRIPTION);
+
     let sdp = encode_sdp(local_description)?;
     let call_request = CallRequest {
         sdp,

--- a/src/rpc/log_prefixes.rs
+++ b/src/rpc/log_prefixes.rs
@@ -8,6 +8,9 @@ pub const MDNS_ADDRESS_FOUND: &'static str = "Found address via mDNS";
 pub const ACQUIRING_AUTH_TOKEN: &'static str = "Acquiring auth token";
 pub const ACQUIRED_AUTH_TOKEN: &'static str = "Acquired auth token";
 
+pub const START_LOCAL_SESSION_DESCRIPTION: &'static str = "Start local session description";
+pub const END_LOCAL_SESSION_DESCRIPTION: &'static str = "End local session description";
+
 pub const DIAL_ATTEMPT: &'static str = "Dialing";
 pub const DIALED_GRPC: &'static str = "Connected via gRPC";
 pub const DIALED_WEBRTC: &'static str = "Connected via WebRTC";


### PR DESCRIPTION
[RSDK-4297](https://viam.atlassian.net/browse/RSDK-4297)

Include the offered local session description in dialdbg's output. It seems like issues with the created session description are common sources of difficult-to-find WebRTC bugs.

New WebRTC output from dialdbg looks like:

```
Debugging dial with WebRTC...

mDNS could not be used to connect
authentication successful in 111ms
offered local session description was
	v=0
	o=- 4176189070910177742 55142000 IN IP4 0.0.0.0
	s=-
	t=0 0
	a=fingerprint:sha-256 [redacted for security]
	a=group:BUNDLE 0
	m=application 9 UDP/DTLS/SCTP webrtc-datachannel
	c=IN IP4 0.0.0.0
	a=setup:actpass
	a=mid:0
	a=sendrecv
	a=sctp-port:5000
	a=ice-ufrag:[redacted for security]
	a=ice-pwd:[redacted for security]
	
WebRTC connection establishment successful in 3494ms
selected ICE candidate pair was:
	(local) udp srflx 74.62.33.18:504670.0.0.0 <-> (remote) udp srflx 71.167.222.76:507040.0.0.0
average RTT across established WebRTC connection: 106ms

nominated ICE candidates:

	remote ICE candidate:
		IP address: 71.167.222.76
		port: 50704
		nominated 400.666µs ago
		relay protocol: udp
		network type: udp4
	remote ICE candidate:
		IP address: 10.1.5.217
		port: 55905
		nominated 403µs ago
		relay protocol: udp
		network type: udp4
	remote ICE candidate:
		IP address: 127.0.0.1
		port: 45984
		nominated 403.541µs ago
		relay protocol: udp
		network type: udp4
	remote ICE candidate:
		IP address: 71.167.222.76
		port: 55905
		nominated 399.666µs ago
		relay protocol: udp
		network type: udp4
	remote ICE candidate:
		IP address: 10.1.5.217
		port: 33688
		nominated 400.958µs ago
		relay protocol: udp
		network type: udp4
	local ICE candidate:
		IP address: eb820f30-74e4-4d41-8da5-0b7d05ef4c4f.local
		port: 58843
		nominated 412.583µs ago
		relay protocol: udp
		network type: udp4
	remote ICE candidate:
		IP address: 71.167.222.76
		port: 59238
		nominated 399.333µs ago
		relay protocol: udp
		network type: udp4
	remote ICE candidate:
		IP address: 71.167.222.76
		port: 52665
		nominated 400µs ago
		relay protocol: udp
		network type: udp4
	local ICE candidate:
		IP address: eb820f30-74e4-4d41-8da5-0b7d05ef4c4f.local
		port: 61543
		nominated 409.25µs ago
		relay protocol: udp
		network type: udp6
	remote ICE candidate:
		IP address: 100.104.116.117
		port: 59238
		nominated 402.458µs ago
		relay protocol: udp
		network type: udp4
	remote ICE candidate:
		IP address: fd7a:115c:a1e0:ab12:4843:cd96:6268:7475
		port: 37556
		nominated 404µs ago
		relay protocol: udp
		network type: udp6
	local ICE candidate:
		IP address: 74.62.33.18
		port: 50467
		nominated 411.291µs ago
		relay protocol: udp
		network type: udp4
	remote ICE candidate:
		IP address: 100.104.116.117
		port: 53446
		nominated 401.625µs ago
		relay protocol: udp
		network type: udp4
	local ICE candidate:
		IP address: 54.244.51.58
		port: 48319
		nominated 410.875µs ago
		relay protocol: udp
		network type: udp4
	remote ICE candidate:
		IP address: 127.0.0.1
		port: 50117
		nominated 401.333µs ago
		relay protocol: udp
		network type: udp4
	remote ICE candidate:
		IP address: fd7a:115c:a1e0:ab12:4843:cd96:6268:7475
		port: 55104
		nominated 404.458µs ago
		relay protocol: udp
		network type: udp6

no mDNS addresses discovered on current subnet

Done debugging dial with WebRTC.
```



[RSDK-4297]: https://viam.atlassian.net/browse/RSDK-4297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ