### PR TITLE
RSDK-1996 - use install_name_tool to fix the install path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
         run: cp target/${{ matrix.target }}/release/libviam_rust_utils.dylib builds/libviam_rust_utils-${{ matrix.platform }}.dylib
       - name: Correct install path
         run: |
-          install_name_tool -id "@rpath/libviam_rust_utils-${{ matrix.platform }}.dylib" builds/libviam_rust_utils-${{ matrix.platform }}.dylib
+          install_name_tool -id "@rpath/libviam_rust_utils.dylib" builds/libviam_rust_utils-${{ matrix.platform }}.dylib
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,9 @@ jobs:
           cargo build --release --target=${{ matrix.target }}
       - name: Copy
         run: cp target/${{ matrix.target }}/release/libviam_rust_utils.dylib builds/libviam_rust_utils-${{ matrix.platform }}.dylib
+      - name: Correct install path
+        run: |
+          install_name_tool -id "@rpath/libviam_rust_utils-${{ matrix.platform }}.dylib" builds/libviam_rust_utils-${{ matrix.platform }}.dylib
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
#### Major changes
Use `install_name_tool` in build action to override the github artifact install name path.

#### Testing
Ran the `install_name_tool` command on a dylib downloaded from github, observed corrected behavior when working with the C++ SDK.