### PR TITLE
RSDK-4447: Add dial timeout

### DIFF
--- a/src/ffi/dial_ffi.rs
+++ b/src/ffi/dial_ffi.rs
@@ -116,7 +116,7 @@ fn dial_with_cred(
 /// * `c_type` a C-style string representing the type of robot's secret you want to use, set to NULL if you don't need authentication
 /// * `c_payload` a C-style string that is the robot's secret, set to NULL if you don't need authentication
 /// * `c_allow_insecure` a bool, set to true when allowing insecure connection to your robot
-/// * `c_timeout` a float, set how long we should try dial before timing out
+/// * `c_timeout` a float, set how long we should try to dial in seconds before timing out
 /// * `rt_ptr` a pointer to a rust runtime previously obtained with init_rust_runtime
 #[no_mangle]
 pub unsafe extern "C" fn dial(

--- a/src/ffi/dial_ffi.rs
+++ b/src/ffi/dial_ffi.rs
@@ -6,7 +6,7 @@
 
 use http::uri::Uri;
 use std::{ptr, time::Duration};
-use tokio::{runtime::Runtime, time::error::Elapsed};
+use tokio::runtime::Runtime;
 use tokio::sync::oneshot;
 use tokio::time::timeout;
 use tracing::Level;
@@ -252,7 +252,7 @@ pub unsafe extern "C" fn dial(
     }) {
         Ok(s) => s,
         Err(e) => {
-            log::error!("Error building GRPC proxy reason : {:?}\n{}", e, e);
+            log::error!("Error building GRPC proxy reason : {}", e);
             return ptr::null_mut();
         }
     };

--- a/src/ffi/dial_ffi.rs
+++ b/src/ffi/dial_ffi.rs
@@ -252,7 +252,7 @@ pub unsafe extern "C" fn dial(
     }) {
         Ok(s) => s,
         Err(e) => {
-            log::error!("Error building GRPC proxy reason : {}", e);
+            log::error!("Error building GRPC proxy reason : {:?}\n{}", e, e);
             return ptr::null_mut();
         }
     };

--- a/src/ffi/dial_ffi.rs
+++ b/src/ffi/dial_ffi.rs
@@ -116,7 +116,7 @@ fn dial_with_cred(
 /// * `c_type` a C-style string representing the type of robot's secret you want to use, set to NULL if you don't need authentication
 /// * `c_payload` a C-style string that is the robot's secret, set to NULL if you don't need authentication
 /// * `c_allow_insecure` a bool, set to true when allowing insecure connection to your robot
-/// * `c_timeout` a float, set how long we should try to dial in seconds before timing out
+/// * `c_timeout` a float, set how many seconds we should try to dial before timing out
 /// * `rt_ptr` a pointer to a rust runtime previously obtained with init_rust_runtime
 #[no_mangle]
 pub unsafe extern "C" fn dial(

--- a/src/ffi/dial_ffi.rs
+++ b/src/ffi/dial_ffi.rs
@@ -6,7 +6,7 @@
 
 use http::uri::Uri;
 use std::{ptr, time::Duration};
-use tokio::runtime::Runtime;
+use tokio::{runtime::Runtime, time::error::Elapsed};
 use tokio::sync::oneshot;
 use tokio::time::timeout;
 use tracing::Level;
@@ -252,8 +252,7 @@ pub unsafe extern "C" fn dial(
     }) {
         Ok(s) => s,
         Err(e) => {
-            let msg = e.to_string();
-            log::error!("Error building GRPC proxy reason : {msg}");
+            log::error!("Error building GRPC proxy reason : {}", e);
             return ptr::null_mut();
         }
     };


### PR DESCRIPTION
[RSDK-4447](https://viam.atlassian.net/browse/RSDK-4447?atlOrigin=eyJpIjoiYmMxYjQwMGQ3ZTAwNGEzMDhjNjA4OTMzOTRmNzgwZjciLCJwIjoiaiJ9)

[Related changes in Python SDK](https://github.com/viamrobotics/viam-python-sdk/pull/444)

[RSDK-4447]: https://viam.atlassian.net/browse/RSDK-4447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Test procedure

- [Test with client that connects to offline robot](https://www.loom.com/share/a8a5661dd1304c55bdbd4ae4e628368c)
- [Test with robot that is online, but edited the rust-utils code to sleep at the end of the answerer code](https://www.loom.com/share/b0f459a1bc674a8b976468ac976f4781?sid=381570a9-fa45-4917-984d-ef1523073312)