### PR TITLE
RSDK-6152 Fix rust-utils release for aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ on:
 jobs:
   prepare:
     if: github.repository_owner == 'viamrobotics'
-    runs-on: [self-hosted, x64]
+    runs-on: [buildjet-8vcpu-ubuntu-2204-arm]
     container:
-      image: ghcr.io/viamrobotics/canon:amd64
+      image: ghcr.io/viamrobotics/canon:arm64
     outputs:
       version: ${{ steps.which_version.outputs.version }}
       sha: ${{ steps.commit.outputs.commit_long_sha }}
@@ -118,6 +118,7 @@ jobs:
           name: builds
           path: builds
 
+  # build_linux builds all but aarch64.
   build_linux:
     if: github.repository_owner == 'viamrobotics'
     needs: [prepare]
@@ -128,9 +129,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: aarch64-unknown-linux-gnu
-            platform: linux_aarch64
-            image: aarch64-unknown-linux-gnu:main-centos
           - target: x86_64-unknown-linux-gnu
             platform: linux_x86_64
             image: x86_64-unknown-linux-gnu:main-centos
@@ -165,8 +163,42 @@ jobs:
           name: builds
           path: builds
 
+  build_aarch64_linux:
+    if: github.repository_owner == 'viamrobotics'
+    needs: [prepare]
+    runs-on: [buildjet-8vcpu-ubuntu-2204-arm]
+    strategy:
+      fail-fast: false
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ needs.prepare.outputs.sha }}
+    # Variables for rust toolchain setup copied from the micro-rdk release
+    # process.
+    - name: Setup rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: 1.70.0
+        override: true
+        target: aarch64-unknown-linux-gnu
+        default: true
+    - name: Setup build directory
+      run: mkdir builds
+    - name: Build
+      run: |
+        cargo build --release --locked --target aarch64-unknown-linux-gnu
+        cp target/aarch64-unknown-linux-gnu/release/libviam_rust_utils.so builds/libviam_rust_utils-aarch64-unknown-linux-gnu.so
+        cp target/aarch64-unknown-linux-gnu/release/libviam_rust_utils.a builds/libviam_rust_utils-aarch64-unknown-linux-gnu.a
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: builds
+        path: builds
+
   release:
-    needs: [prepare, build_macos, build_linux]
+    needs: [prepare, build_macos, build_linux, build_aarch64_linux]
     if: github.repository_owner == 'viamrobotics'
     runs-on: [self-hosted, x64]
     container:


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-6152

Splits `aarch64` building into its own GH job with a slightly different toolchain setup. Runs the `prepare` job on a buildjet `arm64` machine instead of an `amd64` machine.