### PR TITLE
RSDK-6194 rename arm64 release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,8 +189,8 @@ jobs:
     - name: Build
       run: |
         cargo build --release --locked --target aarch64-unknown-linux-gnu
-        cp target/aarch64-unknown-linux-gnu/release/libviam_rust_utils.so builds/libviam_rust_utils-aarch64-unknown-linux-gnu.so
-        cp target/aarch64-unknown-linux-gnu/release/libviam_rust_utils.a builds/libviam_rust_utils-aarch64-unknown-linux-gnu.a
+        cp target/aarch64-unknown-linux-gnu/release/libviam_rust_utils.so builds/libviam_rust_utils-linux_aarch64.so
+        cp target/aarch64-unknown-linux-gnu/release/libviam_rust_utils.a builds/libviam_rust_utils-linux_aarch64.a
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
## What changed
- revert naming style of the aarch64 release artifact to the old style
## Why
- the name of this output changed between 0.1.2 and 0.1.3
- viam-cpp-sdk consumes static rust-utils from github releases [here in CMake](https://github.com/viamrobotics/viam-cpp-sdk/blob/main/CMakeLists.txt#L249)
- this causes some c++ modules to fail on arm (example CI failure [here](https://github.com/viamrobotics/module-example-cpp/actions/runs/7332307759/job/19987973787#step:7:25))
## Other approaches
- if the new format is the superior format we can edit the URL in the cpp sdk instead