### PR TITLE
Migrate runners

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,9 +12,7 @@ on:
 jobs:
   checks:
     if: github.repository_owner == 'viamrobotics'
-    runs-on: [self-hosted, x64]
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Checkout PR/Push/Workflow Dispatch
         uses: actions/checkout@v2

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -10,10 +10,7 @@ on:
 jobs:
   license_finder:
     name: Audit 3rd-Party Licenses
-    runs-on: [x64, qemu-host]
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64-cache
-      options: --platform linux/amd64
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -11,6 +11,9 @@ jobs:
   license_finder:
     name: Audit 3rd-Party Licenses
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/viamrobotics/canon:amd64-cache
+      options: --platform linux/amd64
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,9 +7,7 @@ on:
 jobs:
   publish:
     if: github.repository_owner == 'viamrobotics'
-    runs-on: [self-hosted, x64]
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check if organization member

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,7 @@ jobs:
   release:
     needs: [prepare, build_macos, build_linux]
     if: github.repository_owner == 'viamrobotics'
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/download-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
   test:
     if: github.repository_owner == 'viamrobotics'
     runs-on: buildjet-4vcpu-ubuntu-2204
+    container:
+      image: ghcr.io/viamrobotics/canon:amd64
     steps:
       - name: Checkout PR/Push/Workflow Dispatch
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository_owner == 'viamrobotics'
     runs-on: buildjet-4vcpu-ubuntu-2204
     container:
-      image: ghcr.io/viamrobotics/canon:amd64
+      image: ghcr.io/viamrobotics/canon:amd64-cache
     steps:
       - name: Checkout PR/Push/Workflow Dispatch
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,7 @@ on:
 jobs:
   test:
     if: github.repository_owner == 'viamrobotics'
-    runs-on: [self-hosted, x64]
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Checkout PR/Push/Workflow Dispatch
         uses: actions/checkout@v3

--- a/.github/workflows/update_protos.yml
+++ b/.github/workflows/update_protos.yml
@@ -9,9 +9,7 @@ on:
 jobs:
   update-protos:
     if: github.repository_owner == 'viamrobotics'
-    runs-on: [self-hosted, x64]
-    container:
-      image: ghcr.io/viamrobotics/canon:amd64
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1.7.0
@@ -32,5 +30,5 @@ jobs:
           delete-branch: true
           title: Automated Protos Update
           body: This is an auto-generated PR to update proto definitions. Check the commits to see which repos and commits are responsible for the changes
-          assignees: npmenard,stuqdog
-          reviewers: npmenard,stuqdog
+          assignees: njooma,stuqdog
+          reviewers: njooma,stuqdog


### PR DESCRIPTION
From Slack, we should move our workflows away from self-hosted runners to either github or buildjet hosted:

> github runners start up faster (we host the rdk-devenv image on github, so it's faster for it to pull the image) so are best for small jobs, and better than doing a 2-core runner on buildjet. Anything that really needs 4 cores or more than 4GB of ram should use buildjet probably, and scale appropriately. Typically 4 or 8 core is the right answer. I've not seen a job that can really make full use of 16 cores for a full run (though if you've got one, then it's worth considering.)