### PR TITLE
RSDK-5993 - fallback to non-mdns uri when auth fails

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "viam-rust-utils"
-version = "0.2.0"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "base64 0.13.1",

--- a/src/ffi/dial_ffi.rs
+++ b/src/ffi/dial_ffi.rs
@@ -196,10 +196,13 @@ pub unsafe extern "C" fn dial(
             false => match CStr::from_ptr(c_entity).to_str() {
                 Ok(ent) => Some(ent.to_string()),
                 Err(e) => {
-                    log::error!("Error unexpectedly received an invalid entity string {:?}", e);
+                    log::error!(
+                        "Error unexpectedly received an invalid entity string {:?}",
+                        e
+                    );
                     return ptr::null_mut();
                 }
-            }
+            },
         }
     };
     let timeout_duration = Duration::from_secs_f32(c_timeout);
@@ -207,26 +210,26 @@ pub unsafe extern "C" fn dial(
     let (server, channel) = match runtime.block_on(async move {
         let channel = match (r#type, payload) {
             (Some(t), Some(p)) => {
-                let res = timeout(
-                    timeout_duration, 
+                timeout(
+                    timeout_duration,
                     dial_with_cred(
-                    uri_str,
-                    entity_opt,
-                    t.to_str()?,
-                    p.to_str()?,
-                    allow_insec,
-                    disable_webrtc,
-                )?
-                .connect()
+                        uri_str,
+                        entity_opt,
+                        t.to_str()?,
+                        p.to_str()?,
+                        allow_insec,
+                        disable_webrtc,
+                    )?
+                    .connect(),
                 )
-                .await?;
-                res
+                .await?
             }
             (None, None) => {
-                let res = timeout(
-                    timeout_duration, 
-                    dial_without_cred(uri_str, allow_insec, disable_webrtc)?.connect()).await?;
-                res
+                timeout(
+                    timeout_duration,
+                    dial_without_cred(uri_str, allow_insec, disable_webrtc)?.connect(),
+                )
+                .await?
             }
             (None, Some(_)) => Err(anyhow::anyhow!("Error missing credential: type")),
             (Some(_), None) => Err(anyhow::anyhow!("Error missing credential: payload")),

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -658,7 +658,9 @@ impl DialBuilder<WithCredentials> {
                 if !attempting_mdns {
                     return Err(e);
                 }
-                log::debug!("Error getting auth token: [{e}]. This may be the result of a mismatch between mDNS uri and credentials. Attempting again with auth uri.");
+                log::debug!(
+                    "Error getting auth token: [{e}]. This may be the result of attempting to connect via mDNS with an incorrectly scoped API key. Attempting again without mDNS uri."
+                    );
                 real_channel =
                     Self::create_channel(allow_downgrade, &domain, uri_for_auth, false).await?;
                 get_auth_token(&mut real_channel.clone(), creds, entity).await?


### PR DESCRIPTION
#### Major changes
When attempting to connect with an mDNS uri fails, we now fallthrough and attempt a standard connection.

Attempts to auth to a robot with an org level API key (or presumably any level other than the robot itself) fail when connecting with mDNS. Previously we would just fail; we've now added explicit fallback logic.