### PR TITLE
chore: remove failing musl linux build targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,21 +140,9 @@ jobs:
             platform: musllinux_x86_64
             image: alpine
             runs-on: buildjet-4vcpu-ubuntu-2204
-          - target: aarch64-unknown-linux-musl
-            platform: musllinux_aarch64
-            image: alpine
-            runs-on: buildjet-4vcpu-ubuntu-2204-arm
           - target: arm-unknown-linux-gnueabihf
             platform: linux_armv6l
             image: ghcr.io/cross-rs/arm-unknown-linux-gnueabihf:main
-            runs-on: buildjet-4vcpu-ubuntu-2204
-          - target: arm-unknown-linux-musleabihf
-            platform: musllinux_armv6l
-            image: ghcr.io/cross-rs/arm-unknown-linux-musleabihf:main
-            runs-on: buildjet-4vcpu-ubuntu-2204
-          - target: armv7-unknown-linux-musleabihf
-            platform: musllinux_armv7l
-            image: ghcr.io/cross-rs/armv7-unknown-linux-musleabihf:main
             runs-on: buildjet-4vcpu-ubuntu-2204
           - target: i686-unknown-linux-musl
             platform: musllinux_x86


### PR DESCRIPTION
Unblocking release builds until we can figure out the right parameters to support these targets: https://github.com/viamrobotics/rust-utils/actions/runs/9212826036