### PR TITLE
RSDK-7854 - fix remote uri inference

### DIFF
--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -1264,13 +1264,3 @@ fn metadata_from_parts(parts: &http::request::Parts) -> Metadata {
     }
     Metadata { md }
 }
-
-fn amend_domain_if_local(domain: &str) -> &str {
-    let localhost = "127.";
-    let localhost_hum = "localhost";
-    if domain.starts_with(localhost) || domain.starts_with(localhost_hum) {
-        "localhost:8080"
-    } else {
-        domain
-    }
-}

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -496,7 +496,6 @@ impl DialBuilder<WithoutCredentials> {
         let uri2 = original_uri.clone();
         let uri = infer_remote_uri_from_authority(original_uri);
         let domain = uri2.authority().to_owned().unwrap().as_str();
-        let domain = amend_domain_if_local(domain);
 
         let mdns_uri = mdns_uri.and_then(|p| Uri::from_parts(p).ok());
         let attempting_mdns = mdns_uri.is_some();
@@ -1226,11 +1225,10 @@ fn encode_sdp(sdp: RTCSessionDescription) -> Result<String> {
 }
 
 fn infer_remote_uri_from_authority(uri: Uri) -> Uri {
-    let is_local_connection = uri
-        .authority()
-        .map(Authority::as_str)
-        .unwrap_or_default()
-        .contains(".local.cloud");
+    let authority = uri.authority().map(Authority::as_str).unwrap_or_default();
+    let is_local_connection = authority.contains(".local.viam.cloud")
+        || authority.contains("localhost")
+        || authority.contains("0.0.0.0");
 
     if !is_local_connection {
         if let Some((new_uri, _)) = Options::infer_signaling_server_address(&uri) {


### PR DESCRIPTION
Fixes an issue whereby we were improperly inferring when a connection was local by looking for `local.cloud` rather than `local.*viam*.cloud`.

This fixes grpc connection to the `local.viam.cloud` addresses, but does not yet fix connection to `localhost:8080`. Will continue to look into that in subsequent PRs but wanted to lock this in now.