### PR TITLE
RSDK-7282 Log ICE event timings/stats

### DIFF
--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -959,7 +959,7 @@ async fn maybe_connect_via_webrtc(
                 Box::pin(async move {
                     if state == RTCIceConnectionState::Completed {
                         let caller_update_stats_inner = caller_update_stats.lock().unwrap();
-                        log::info!("{}", caller_update_stats_inner);
+                        log::debug!("{}", caller_update_stats_inner);
                     }
                 })
             },
@@ -1005,7 +1005,7 @@ async fn maybe_connect_via_webrtc(
                     let mut signaling_client = SignalingServiceClient::new(channel.clone());
                     match ice_candidate {
                         Some(ice_candidate) => {
-                            log::info!("Gathered local candidate of {}", ice_candidate);
+                            log::debug!("Gathered local candidate of {}", ice_candidate);
                             if sent_done_or_error.load(Ordering::Acquire) {
                                 return;
                             }
@@ -1197,7 +1197,7 @@ async fn maybe_connect_via_webrtc(
                                     break;
                                 }
                             };
-                            log::info!("Received remote ICE candidate of {:#?}", candidate);
+                            log::debug!("Received remote ICE candidate of {:#?}", candidate);
                             if let Err(e) = client_channel
                                 .base_channel
                                 .peer_connection

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -884,7 +884,7 @@ impl fmt::Display for CallerUpdateStats {
         let average_duration = &self.total_duration.as_millis() / &self.count;
         writeln!(
             f,
-            "Caller update statistics: num_updates {}, average_duration: {}ms, max_duration: {}ms",
+            "Caller update statistics: num_updates: {}, average_duration: {}ms, max_duration: {}ms",
             &self.count,
             average_duration,
             &self.max_duration.as_millis()
@@ -1005,7 +1005,7 @@ async fn maybe_connect_via_webrtc(
                     let mut signaling_client = SignalingServiceClient::new(channel.clone());
                     match ice_candidate {
                         Some(ice_candidate) => {
-                            log::debug!("Gathered local candidate of {}", ice_candidate);
+                            log::debug!("Gathered local candidate of {ice_candidate}");
                             if sent_done_or_error.load(Ordering::Acquire) {
                                 return;
                             }
@@ -1039,7 +1039,8 @@ async fn maybe_connect_via_webrtc(
                                         caller_update_stats_inner.max_duration =
                                             call_update_duration;
                                     }
-                                    caller_update_stats_inner.total_duration = call_update_duration;
+                                    caller_update_stats_inner.total_duration +=
+                                        call_update_duration;
                                 }
                                 Err(e) => log::error!("Error parsing ice candidate: {e}"),
                             }
@@ -1197,7 +1198,7 @@ async fn maybe_connect_via_webrtc(
                                     break;
                                 }
                             };
-                            log::debug!("Received remote ICE candidate of {:#?}", candidate);
+                            log::debug!("Received remote ICE candidate of {candidate:#?}");
                             if let Err(e) = client_channel
                                 .base_channel
                                 .peer_connection


### PR DESCRIPTION
[RSDK-7282](https://viam.atlassian.net/browse/RSDK-7282)

Adds info-level logs for:
- Gathering of local ICE candidates
- Reception of remote ICE candidates
- Statistics of caller updates for this connection establishment
     - Number of updates
     - Average duration of update
     - Max duration of update

[RSDK-7282]: https://viam.atlassian.net/browse/RSDK-7282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ