### PR TITLE
chore(release): add ARM musl build targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,5 +4,11 @@ rustflags = [ "-C", "target-feature=-crt-static" ]
 [target.aarch64-unknown-linux-musl]
 rustflags = [ "-C", "target-feature=-crt-static" ]
 
+[target.arm-unknown-linux-musleabihf]
+rustflags = [ "-C", "target-feature=-crt-static" ]
+
+[target.armv7-unknown-linux-musleabihf]
+rustflags = [ "-C", "target-feature=-crt-static" ]
+
 [target.i686-unknown-linux-musl]
 rustflags = [ "-C", "target-feature=-crt-static" ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,9 +140,21 @@ jobs:
             platform: musllinux_x86_64
             image: alpine
             runs-on: buildjet-4vcpu-ubuntu-2204
+          - target: aarch64-unknown-linux-musl
+            platform: musllinux_aarch64
+            image: ghcr.io/cross-rs/aarch64-unknown-linux-musl:main
+            runs-on: buildjet-4vcpu-ubuntu-2204
           - target: arm-unknown-linux-gnueabihf
             platform: linux_armv6l
             image: ghcr.io/cross-rs/arm-unknown-linux-gnueabihf:main
+            runs-on: buildjet-4vcpu-ubuntu-2204
+          - target: arm-unknown-linux-musleabihf
+            platform: linux_armv6l
+            image: ghcr.io/cross-rs/arm-unknown-linux-musleabihf:main
+            runs-on: buildjet-4vcpu-ubuntu-2204
+          - target: armv7-unknown-linux-musleabihf
+            platform: linux_armv7l
+            image: ghcr.io/cross-rs/armv7-unknown-linux-musleabihf:main
             runs-on: buildjet-4vcpu-ubuntu-2204
           - target: i686-unknown-linux-musl
             platform: musllinux_x86


### PR DESCRIPTION
Second attempt to add `musl` support for aarch64/arm build targets to support in-progress Home Assistant core integration, which requires the Python SDK to run on more platforms. See #112 for more information. 