### PR TITLE
RSDK-9518 - update to Artifacts v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,8 +198,18 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: builds
+          name: builds-${{ matrix.platform }}
           path: builds/*
+
+  merge:
+    needs: [build_macos, build_linux]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: builds
+          pattern: builds-*
 
   release:
     needs: [prepare, build_macos, build_linux]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: builds
-          path: builds
+          path: builds/*
 
   release:
     needs: [prepare, build_macos, build_linux]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,10 +100,10 @@ jobs:
         run: |
           install_name_tool -id "@rpath/libviam_rust_utils.dylib" builds/libviam_rust_utils-${{ matrix.platform }}.dylib
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: builds
-          path: builds
+          name: builds-${{ matrix.platform }}
+          path: builds/*
 
   build_linux:
     if: github.repository_owner == 'viamrobotics'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,7 +207,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4.1.7
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,7 +196,7 @@ jobs:
           cp target/${{ matrix.target }}/release/libviam_rust_utils.so builds/libviam_rust_utils-${{ matrix.platform }}.so
           cp target/${{ matrix.target }}/release/libviam_rust_utils.a builds/libviam_rust_utils-${{ matrix.platform }}.a
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: builds
           path: builds
@@ -207,7 +207,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v4
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,7 @@ jobs:
           pattern: builds-*
 
   release:
-    needs: [prepare, build_macos, build_linux]
+    needs: [prepare, merge]
     if: github.repository_owner == 'viamrobotics'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
             runs-on: buildjet-8vcpu-ubuntu-2204-arm
           - target: x86_64-unknown-linux-gnu
             platform: linux_x86_64
-            image: ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main-centos
+            image: ubuntu:18.04
             runs-on: buildjet-4vcpu-ubuntu-2204
           - target: x86_64-unknown-linux-musl
             platform: musllinux_x86_64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
             runs-on: buildjet-8vcpu-ubuntu-2204-arm
           - target: x86_64-unknown-linux-gnu
             platform: linux_x86_64
-            image: ubuntu:18.04
+            image: ubuntu:20.04
             runs-on: buildjet-4vcpu-ubuntu-2204
           - target: x86_64-unknown-linux-musl
             platform: musllinux_x86_64


### PR DESCRIPTION
All of this work was done by @njooma a couple months ago. All necessary testing to show that it could successfully build and run the upload artifacts job was done at that time. At the time the work was abandoned because there was an issue whereby we couldn't build and upload on ubuntu 18.04 while using `upload-artifacts@v4`. This was deemed unacceptable because `ubuntu 18.04` is necessary for ROS melodic, which many existing robotics companies use.

We have since determined that it's fine to deprecate support for ubuntu 18.04. Three factors influenced that choice:
1) `upload-artifacts@v3` will no longer work come end of January so we have to update it now,
2) no existing customers use ROS melodic or require ubuntu 18.04 support, and 
3) if such a customer comes along, we can make a custom workflow to support their specific use case pretty easily
