### PR TITLE
Update license_finder.yml

### DIFF
--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -28,4 +28,6 @@ jobs:
           toolchain: stable
 
       - name: Run license finder
-        run: license_finder
+        run: |
+          license_finder permitted_licenses add Unicode-3.0
+          license_finder


### PR DESCRIPTION
This job has been failing because we don't have `Unicode-3.0` on the list of permitted licenses. So, let's add it.