### PR TITLE
[RSDK-13658] Add force relay and force p2p dial flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,4 +68,3 @@ env_logger = "0.9.0"
 [build-dependencies]
 tonic-build = {version = "0.9.2",features = ["prost"]}
 cbindgen = "0.29.2"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,4 @@ env_logger = "0.9.0"
 [build-dependencies]
 tonic-build = {version = "0.9.2",features = ["prost"]}
 cbindgen = "0.29.2"
+

--- a/src/dialdbg/main.rs
+++ b/src/dialdbg/main.rs
@@ -61,6 +61,30 @@ pub(crate) struct Args {
     /// URI to dial. Must be provided.
     #[arg(short, long, required(true), display_order(0))]
     uri: Option<String>,
+
+    /// Force ICE transport policy to relay-only (only TURN candidates). Implies WebRTC.
+    #[arg(long, action, conflicts_with("nowebrtc"), conflicts_with("force_p2p"))]
+    force_relay: bool,
+
+    /// Strip TURN servers so only host/srflx candidates are used. Implies WebRTC.
+    #[arg(long, action, conflicts_with("nowebrtc"), conflicts_with("force_relay"))]
+    force_p2p: bool,
+
+    /// Override the signaling server address used for WebRTC negotiation. Useful for
+    /// testing against a specific app deployment (e.g. a Cloud Run PR deploy).
+    #[arg(long, conflicts_with("nowebrtc"))]
+    signaling_server: Option<String>,
+
+    /// Disable mDNS discovery. Useful when the robot is on the same local network and
+    /// you want to test cloud relay without mDNS bypassing it.
+    #[arg(long, action)]
+    disable_mdns: bool,
+
+    /// Retain only ICE servers whose URLs contain this host string. Applied after the full
+    /// ICE server list is assembled. Useful for isolating a specific TURN server, e.g.
+    /// "--force-relay --relay-host 34.9.65.195" to route only through coturn.
+    #[arg(long, conflicts_with("nowebrtc"))]
+    relay_host: Option<String>,
 }
 
 async fn dial_grpc(
@@ -111,15 +135,34 @@ async fn dial_webrtc(
     credential: &str,
     credential_type: &str,
     entity: Option<String>,
+    force_relay: bool,
+    force_p2p: bool,
+    relay_host: Option<String>,
+    signaling_server: Option<String>,
+    disable_mdns: bool,
 ) -> Option<ViamChannel> {
     let dial_result = match credential {
         "" => {
-            dial::DialOptions::builder()
+            let mut b = dial::DialOptions::builder()
                 .uri(uri)
                 .without_credentials()
-                .allow_downgrade()
-                .connect()
-                .await
+                .allow_downgrade();
+            if force_relay {
+                b = b.force_relay();
+            }
+            if force_p2p {
+                b = b.force_p2p();
+            }
+            if let Some(host) = relay_host {
+                b = b.relay_host_filter(host);
+            }
+            if let Some(server) = signaling_server {
+                b = b.signaling_server(server);
+            }
+            if disable_mdns {
+                b = b.disable_mdns();
+            }
+            b.connect().await
         }
         _ => {
             let creds = dial::RPCCredentials::new(
@@ -127,12 +170,26 @@ async fn dial_webrtc(
                 credential_type.to_string(),
                 credential.to_string(),
             );
-            dial::DialOptions::builder()
+            let mut b = dial::DialOptions::builder()
                 .uri(uri)
                 .with_credentials(creds)
-                .allow_downgrade()
-                .connect()
-                .await
+                .allow_downgrade();
+            if force_relay {
+                b = b.force_relay();
+            }
+            if force_p2p {
+                b = b.force_p2p();
+            }
+            if let Some(host) = relay_host {
+                b = b.relay_host_filter(host);
+            }
+            if let Some(server) = signaling_server {
+                b = b.signaling_server(server);
+            }
+            if disable_mdns {
+                b = b.disable_mdns();
+            }
+            b.connect().await
         }
     };
 
@@ -287,6 +344,11 @@ pub(crate) async fn main_inner(args: Args) -> Result<()> {
             credential.as_str(),
             credential_type.as_str(),
             args.entity.clone(),
+            args.force_relay,
+            args.force_p2p,
+            args.relay_host.clone(),
+            args.signaling_server.clone(),
+            args.disable_mdns,
         )
         .await;
         let wrtc_res = parse::parse_webrtc_logs(log_path.clone(), &mut out)?;

--- a/src/dialdbg/main.rs
+++ b/src/dialdbg/main.rs
@@ -70,11 +70,11 @@ pub(crate) struct Args {
     #[arg(long, action, conflicts_with("nowebrtc"), conflicts_with("force_relay"))]
     force_p2p: bool,
 
-    /// Filter assembled ICE servers to only TURN servers whose URL contains this
-    /// substring. Can be combined with --force-relay to route through a specific
-    /// TURN server. Implies WebRTC.
+    /// Filter the signaling server's TURN list to only the server whose parsed URI
+    /// matches. Uses the same struct comparison as the server-side TURN_URI env var.
+    /// Example: "turn:turn.viam.com:443". Implies WebRTC.
     #[arg(long, conflicts_with("nowebrtc"))]
-    relay_host_filter: Option<String>,
+    turn_uri: Option<String>,
 
     /// Override the signaling server address used for WebRTC negotiation. Useful for
     /// testing against a specific app deployment (e.g. a Cloud Run PR deploy).
@@ -138,7 +138,7 @@ async fn dial_webrtc(
     entity: Option<String>,
     force_relay: bool,
     force_p2p: bool,
-    relay_host_filter: Option<String>,
+    turn_uri: Option<String>,
     signaling_server: Option<String>,
     disable_mdns: bool,
 ) -> Option<ViamChannel> {
@@ -154,8 +154,8 @@ async fn dial_webrtc(
             if force_p2p {
                 b = b.force_p2p();
             }
-            if let Some(host) = relay_host_filter {
-                b = b.relay_host_filter(host);
+            if let Some(u) = turn_uri {
+                b = b.turn_uri(u);
             }
             if let Some(server) = signaling_server {
                 b = b.signaling_server(server);
@@ -181,8 +181,8 @@ async fn dial_webrtc(
             if force_p2p {
                 b = b.force_p2p();
             }
-            if let Some(host) = relay_host_filter {
-                b = b.relay_host_filter(host);
+            if let Some(u) = turn_uri {
+                b = b.turn_uri(u);
             }
             if let Some(server) = signaling_server {
                 b = b.signaling_server(server);
@@ -347,7 +347,7 @@ pub(crate) async fn main_inner(args: Args) -> Result<()> {
             args.entity.clone(),
             args.force_relay,
             args.force_p2p,
-            args.relay_host_filter.clone(),
+            args.turn_uri.clone(),
             args.signaling_server.clone(),
             args.disable_mdns,
         )

--- a/src/dialdbg/main.rs
+++ b/src/dialdbg/main.rs
@@ -63,8 +63,10 @@ pub(crate) struct Args {
     uri: Option<String>,
 
     /// Force ICE transport policy to relay-only (only TURN candidates). Implies WebRTC.
-    #[arg(long, action, conflicts_with("nowebrtc"), conflicts_with("force_p2p"))]
-    force_relay: bool,
+    /// Optionally accepts a host string to filter to a specific TURN server, e.g.
+    /// "--force-relay 34.9.65.195" or "--force-relay turn.viam.com".
+    #[arg(long, num_args(0..=1), default_missing_value = "", conflicts_with("nowebrtc"), conflicts_with("force_p2p"))]
+    force_relay: Option<String>,
 
     /// Strip TURN servers so only host/srflx candidates are used. Implies WebRTC.
     #[arg(long, action, conflicts_with("nowebrtc"), conflicts_with("force_relay"))]
@@ -80,11 +82,6 @@ pub(crate) struct Args {
     #[arg(long, action)]
     disable_mdns: bool,
 
-    /// Retain only ICE servers whose URLs contain this host string. Applied after the full
-    /// ICE server list is assembled. Useful for isolating a specific TURN server, e.g.
-    /// "--force-relay --relay-host 34.9.65.195" to route only through coturn.
-    #[arg(long, conflicts_with("nowebrtc"))]
-    relay_host: Option<String>,
 }
 
 async fn dial_grpc(
@@ -135,9 +132,8 @@ async fn dial_webrtc(
     credential: &str,
     credential_type: &str,
     entity: Option<String>,
-    force_relay: bool,
+    force_relay: Option<String>,
     force_p2p: bool,
-    relay_host: Option<String>,
     signaling_server: Option<String>,
     disable_mdns: bool,
 ) -> Option<ViamChannel> {
@@ -147,14 +143,14 @@ async fn dial_webrtc(
                 .uri(uri)
                 .without_credentials()
                 .allow_downgrade();
-            if force_relay {
+            if let Some(ref host) = force_relay {
                 b = b.force_relay();
+                if !host.is_empty() {
+                    b = b.relay_host_filter(host.clone());
+                }
             }
             if force_p2p {
                 b = b.force_p2p();
-            }
-            if let Some(host) = relay_host {
-                b = b.relay_host_filter(host);
             }
             if let Some(server) = signaling_server {
                 b = b.signaling_server(server);
@@ -174,14 +170,14 @@ async fn dial_webrtc(
                 .uri(uri)
                 .with_credentials(creds)
                 .allow_downgrade();
-            if force_relay {
+            if let Some(ref host) = force_relay {
                 b = b.force_relay();
+                if !host.is_empty() {
+                    b = b.relay_host_filter(host.clone());
+                }
             }
             if force_p2p {
                 b = b.force_p2p();
-            }
-            if let Some(host) = relay_host {
-                b = b.relay_host_filter(host);
             }
             if let Some(server) = signaling_server {
                 b = b.signaling_server(server);
@@ -344,9 +340,8 @@ pub(crate) async fn main_inner(args: Args) -> Result<()> {
             credential.as_str(),
             credential_type.as_str(),
             args.entity.clone(),
-            args.force_relay,
+            args.force_relay.clone(),
             args.force_p2p,
-            args.relay_host.clone(),
             args.signaling_server.clone(),
             args.disable_mdns,
         )

--- a/src/dialdbg/main.rs
+++ b/src/dialdbg/main.rs
@@ -71,13 +71,12 @@ pub(crate) struct Args {
     force_p2p: bool,
 
     /// Filter the signaling server's TURN list to only the server whose parsed URI
-    /// matches. Uses the same struct comparison as the server-side TURN_URI env var.
+    /// matches.
     /// Example: "turn:turn.viam.com:443". Implies WebRTC.
     #[arg(long, conflicts_with("nowebrtc"))]
     turn_uri: Option<String>,
 
-    /// Override the signaling server address used for WebRTC negotiation. Useful for
-    /// testing against a specific app deployment (e.g. a Cloud Run PR deploy).
+    /// Override the signaling server address used for WebRTC negotiation.
     #[arg(long, conflicts_with("nowebrtc"))]
     signaling_server: Option<String>,
 

--- a/src/dialdbg/main.rs
+++ b/src/dialdbg/main.rs
@@ -67,12 +67,16 @@ pub(crate) struct Args {
     force_relay: bool,
 
     /// Strip TURN servers so only host/srflx candidates are used. Implies WebRTC.
-    #[arg(long, action, conflicts_with("nowebrtc"), conflicts_with("force_relay"))]
+    #[arg(
+        long,
+        action,
+        conflicts_with("nowebrtc"),
+        conflicts_with("force_relay")
+    )]
     force_p2p: bool,
 
     /// Filter the signaling server's TURN list to only the server whose parsed URI
-    /// matches.
-    /// Example: "turn:turn.viam.com:443". Implies WebRTC.
+    /// matches. Example: "turn:turn.viam.com:443". Implies WebRTC.
     #[arg(long, conflicts_with("nowebrtc"))]
     turn_uri: Option<String>,
 
@@ -84,7 +88,6 @@ pub(crate) struct Args {
     /// you want to test cloud relay without mDNS bypassing it.
     #[arg(long, action)]
     disable_mdns: bool,
-
 }
 
 async fn dial_grpc(

--- a/src/dialdbg/main.rs
+++ b/src/dialdbg/main.rs
@@ -70,6 +70,12 @@ pub(crate) struct Args {
     #[arg(long, action, conflicts_with("nowebrtc"), conflicts_with("force_relay"))]
     force_p2p: bool,
 
+    /// Filter assembled ICE servers to only TURN servers whose URL contains this
+    /// substring. Can be combined with --force-relay to route through a specific
+    /// TURN server. Implies WebRTC.
+    #[arg(long, conflicts_with("nowebrtc"))]
+    relay_host_filter: Option<String>,
+
     /// Override the signaling server address used for WebRTC negotiation. Useful for
     /// testing against a specific app deployment (e.g. a Cloud Run PR deploy).
     #[arg(long, conflicts_with("nowebrtc"))]
@@ -132,6 +138,7 @@ async fn dial_webrtc(
     entity: Option<String>,
     force_relay: bool,
     force_p2p: bool,
+    relay_host_filter: Option<String>,
     signaling_server: Option<String>,
     disable_mdns: bool,
 ) -> Option<ViamChannel> {
@@ -146,6 +153,9 @@ async fn dial_webrtc(
             }
             if force_p2p {
                 b = b.force_p2p();
+            }
+            if let Some(host) = relay_host_filter {
+                b = b.relay_host_filter(host);
             }
             if let Some(server) = signaling_server {
                 b = b.signaling_server(server);
@@ -170,6 +180,9 @@ async fn dial_webrtc(
             }
             if force_p2p {
                 b = b.force_p2p();
+            }
+            if let Some(host) = relay_host_filter {
+                b = b.relay_host_filter(host);
             }
             if let Some(server) = signaling_server {
                 b = b.signaling_server(server);
@@ -334,6 +347,7 @@ pub(crate) async fn main_inner(args: Args) -> Result<()> {
             args.entity.clone(),
             args.force_relay,
             args.force_p2p,
+            args.relay_host_filter.clone(),
             args.signaling_server.clone(),
             args.disable_mdns,
         )

--- a/src/dialdbg/main.rs
+++ b/src/dialdbg/main.rs
@@ -63,10 +63,8 @@ pub(crate) struct Args {
     uri: Option<String>,
 
     /// Force ICE transport policy to relay-only (only TURN candidates). Implies WebRTC.
-    /// Optionally accepts a host string to filter to a specific TURN server, e.g.
-    /// "--force-relay 34.9.65.195" or "--force-relay turn.viam.com".
-    #[arg(long, num_args(0..=1), default_missing_value = "", conflicts_with("nowebrtc"), conflicts_with("force_p2p"))]
-    force_relay: Option<String>,
+    #[arg(long, action, conflicts_with("nowebrtc"), conflicts_with("force_p2p"))]
+    force_relay: bool,
 
     /// Strip TURN servers so only host/srflx candidates are used. Implies WebRTC.
     #[arg(long, action, conflicts_with("nowebrtc"), conflicts_with("force_relay"))]
@@ -132,7 +130,7 @@ async fn dial_webrtc(
     credential: &str,
     credential_type: &str,
     entity: Option<String>,
-    force_relay: Option<String>,
+    force_relay: bool,
     force_p2p: bool,
     signaling_server: Option<String>,
     disable_mdns: bool,
@@ -143,11 +141,8 @@ async fn dial_webrtc(
                 .uri(uri)
                 .without_credentials()
                 .allow_downgrade();
-            if let Some(ref host) = force_relay {
+            if force_relay {
                 b = b.force_relay();
-                if !host.is_empty() {
-                    b = b.relay_host_filter(host.clone());
-                }
             }
             if force_p2p {
                 b = b.force_p2p();
@@ -170,11 +165,8 @@ async fn dial_webrtc(
                 .uri(uri)
                 .with_credentials(creds)
                 .allow_downgrade();
-            if let Some(ref host) = force_relay {
+            if force_relay {
                 b = b.force_relay();
-                if !host.is_empty() {
-                    b = b.relay_host_filter(host.clone());
-                }
             }
             if force_p2p {
                 b = b.force_p2p();
@@ -340,7 +332,7 @@ pub(crate) async fn main_inner(args: Args) -> Result<()> {
             credential.as_str(),
             credential_type.as_str(),
             args.entity.clone(),
-            args.force_relay.clone(),
+            args.force_relay,
             args.force_p2p,
             args.signaling_server.clone(),
             args.disable_mdns,

--- a/src/dialdbg/stats.rs
+++ b/src/dialdbg/stats.rs
@@ -7,7 +7,45 @@ impl fmt::Display for StatsReport {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // NOTE(benjirewis): StatsReport contains 13 types of stat reports; there may be more relevant stats
         // to print here, but for now I have stuck with only printing the candidates.
-        writeln!(f, "\nnominated ICE candidates:\n")?;
+        writeln!(f, "\nnominated ICE candidate pair:\n")?;
+
+        // Find the nominated candidate pair first, then look up its local/remote
+        // candidates by ID so we only print the pair that was actually used.
+        let nominated_pair = self.0.reports.values().find_map(|v| {
+            if let stats::StatsReportType::CandidatePair(ref pair) = v {
+                if pair.nominated {
+                    return Some(pair);
+                }
+            }
+            None
+        });
+
+        if let Some(pair) = nominated_pair {
+            for (id, label) in [
+                (&pair.local_candidate_id, "local"),
+                (&pair.remote_candidate_id, "remote"),
+            ] {
+                let cand = self.0.reports.get(id).and_then(|v| match v {
+                    stats::StatsReportType::LocalCandidate(c)
+                    | stats::StatsReportType::RemoteCandidate(c) => Some(c),
+                    _ => None,
+                });
+                let Some(cand) = cand else {
+                    continue;
+                };
+                writeln!(f, "\t{label} ICE candidate:")?;
+                writeln!(f, "\t\tIP address: {}", cand.ip)?;
+                writeln!(f, "\t\tport: {}", cand.port)?;
+                writeln!(f, "\t\tcandidate type: {}", cand.candidate_type)?;
+                writeln!(f, "\t\tnominated {:#?} ago", cand.timestamp.elapsed())?;
+                writeln!(f, "\t\trelay protocol: {}", cand.relay_protocol)?;
+                writeln!(f, "\t\tnetwork type: {}", cand.network_type)?;
+            }
+        } else {
+            writeln!(f, "\t(no nominated pair found)")?;
+        }
+
+        writeln!(f, "\nall ICE candidates:\n")?;
         for (_, value) in &self.0.reports {
             match value {
                 stats::StatsReportType::LocalCandidate(ref cand)
@@ -20,6 +58,7 @@ impl fmt::Display for StatsReport {
                     writeln!(f, "\t{} ICE candidate:", remote_or_local)?;
                     writeln!(f, "\t\tIP address: {}", cand.ip)?;
                     writeln!(f, "\t\tport: {}", cand.port)?;
+                    writeln!(f, "\t\tcandidate type: {}", cand.candidate_type)?;
                     writeln!(f, "\t\tnominated {:#?} ago", cand.timestamp.elapsed())?;
                     writeln!(f, "\t\trelay protocol: {}", cand.relay_protocol)?;
                     writeln!(f, "\t\tnetwork type: {}", cand.network_type)?;

--- a/src/dialdbg/stats.rs
+++ b/src/dialdbg/stats.rs
@@ -25,7 +25,7 @@ impl fmt::Display for StatsReport {
                     writeln!(
                         f,
                         "\t\tnominated {:#?} ago",
-                        now.duration_since(cand.timestamp)
+                        now.checked_duration_since(cand.timestamp).unwrap_or_default()
                     )?;
                     writeln!(f, "\t\trelay protocol: {}", cand.relay_protocol)?;
                     writeln!(f, "\t\tnetwork type: {}", cand.network_type)?;

--- a/src/dialdbg/stats.rs
+++ b/src/dialdbg/stats.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use tokio::time::Instant;
 use webrtc::stats;
 
 pub(crate) struct StatsReport(pub(crate) stats::StatsReport);
@@ -9,7 +8,6 @@ impl fmt::Display for StatsReport {
         // NOTE(benjirewis): StatsReport contains 13 types of stat reports; there may be more relevant stats
         // to print here, but for now I have stuck with only printing the candidates.
         writeln!(f, "\nnominated ICE candidates:\n")?;
-        let now = Instant::now();
         for (_, value) in &self.0.reports {
             match value {
                 stats::StatsReportType::LocalCandidate(ref cand)
@@ -22,11 +20,7 @@ impl fmt::Display for StatsReport {
                     writeln!(f, "\t{} ICE candidate:", remote_or_local)?;
                     writeln!(f, "\t\tIP address: {}", cand.ip)?;
                     writeln!(f, "\t\tport: {}", cand.port)?;
-                    writeln!(
-                        f,
-                        "\t\tnominated {:#?} ago",
-                        now.checked_duration_since(cand.timestamp).unwrap_or_default()
-                    )?;
+                    writeln!(f, "\t\tnominated {:#?} ago", cand.timestamp.elapsed())?;
                     writeln!(f, "\t\trelay protocol: {}", cand.relay_protocol)?;
                     writeln!(f, "\t\tnetwork type: {}", cand.network_type)?;
                 }

--- a/src/dialdbg/test-relay-and-p2p-dial-opts.sh
+++ b/src/dialdbg/test-relay-and-p2p-dial-opts.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 cargo build --features dialdbg --bin viam-dialdbg 2>&1 | tail -1
 BINARY=./target/debug/viam-dialdbg
 
-HOST="<machine-fqdn>"
-ENTITY="<api-key-id>"
-APIKEY="<api-key>"
-# RELAY_HOST should be a substring matching at least one TURN server URL returned
-# by the signaling server (e.g. "turn.viam.com" for prod coturn).
-RELAY_HOST="<relay-host-substring>"
+HOST="machine-main.ozy75nuoux.viam.cloud"
+ENTITY="4f04c6ca-b9df-440d-82db-6d383b0c92a1"
+APIKEY="ymw99jc6h6ki2m9rlhzekp8r2tpj9zjy"
+# TURN_URI should be the URI of a TURN server returned by the signaling server.
+# Example: "turn:turn.viam.com:443"
+TURN_URI="turn:turn.viam.com:443"
 COMMON=(-u "$HOST" -e "$ENTITY" -t api-key -c "$APIKEY" --nogrpc --nortt)
 
 PASS=0
@@ -76,19 +76,17 @@ assert "baseline (no flags)" "$(run)" "!relay"
 # 2. ForceRelay — expect relay
 assert "ForceRelay" "$(run --force-relay)" "relay"
 
-# 3. ForceRelay + RelayHostFilter matching a valid TURN server — expect relay
-assert "ForceRelay + RelayHostFilter" "$(run --force-relay --relay-host-filter "$RELAY_HOST")" "relay"
+# 3. ForceRelay + TurnUri matching a valid TURN server — expect relay
+assert "ForceRelay + TurnUri" "$(run --force-relay --turn-uri "$TURN_URI")" "relay"
 
 # 4. ForceP2P — expect non-relay (host or srflx)
 assert "ForceP2P" "$(run --force-p2p)" "!relay"
 
-# 5. RelayHostFilter alone — filter limits TURN options but ICE still picks
-# host/srflx; expect non-relay
-assert "RelayHostFilter (no ForceRelay)" "$(run --relay-host-filter "$RELAY_HOST")" "!relay"
+# 5. TurnUri alone — filters TURN options but ICE still picks host/srflx; expect non-relay
+assert "TurnUri (no ForceRelay)" "$(run --turn-uri "$TURN_URI")" "!relay"
 
-# 6. ForceRelay + non-matching RelayHostFilter — all TURN filtered out,
-# no relay candidates, expect failure
-assert "ForceRelay + RelayHostFilter=notexist (expect: fail)" "$(run --force-relay --relay-host-filter notexist.example.com)" "none"
+# 6. ForceRelay + non-matching TurnUri — all TURN filtered out, no relay candidates, expect failure
+assert "ForceRelay + TurnUri=notexist (expect: fail)" "$(run --force-relay --turn-uri "turn:notexist.example.com:3478")" "none"
 
 printf '\n%d passed, %d failed.\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/src/dialdbg/test-relay-and-p2p-dial-opts.sh
+++ b/src/dialdbg/test-relay-and-p2p-dial-opts.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 cargo build --features dialdbg --bin viam-dialdbg 2>&1 | tail -1
 BINARY=./target/debug/viam-dialdbg
 
-HOST="machine-main.ozy75nuoux.viam.cloud"
-ENTITY="4f04c6ca-b9df-440d-82db-6d383b0c92a1"
-APIKEY="ymw99jc6h6ki2m9rlhzekp8r2tpj9zjy"
+HOST="<machine-fqdn>"
+ENTITY="<api-key-id>"
+APIKEY="<api-key>"
 # TURN_URI should be the URI of a TURN server returned by the signaling server.
 # Example: "turn:turn.viam.com:443"
-TURN_URI="turn:turn.viam.com:443"
+TURN_URI="<turn-uri>"
 COMMON=(-u "$HOST" -e "$ENTITY" -t api-key -c "$APIKEY" --nogrpc --nortt)
 
 PASS=0

--- a/src/dialdbg/test-relay-and-p2p-dial-opts.sh
+++ b/src/dialdbg/test-relay-and-p2p-dial-opts.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 cargo build --features dialdbg --bin viam-dialdbg 2>&1 | tail -1
 BINARY=./target/debug/viam-dialdbg
 
-HOST="machine-main.ozy75nuoux.viam.cloud"
-ENTITY="4f04c6ca-b9df-440d-82db-6d383b0c92a1"
-APIKEY="ymw99jc6h6ki2m9rlhzekp8r2tpj9zjy"
+HOST=""
+ENTITY=""
+APIKEY=""
 COMMON=(-u "$HOST" -e "$ENTITY" -t api-key -c "$APIKEY" --nogrpc --nortt)
 
 PASS=0

--- a/src/dialdbg/test-relay-and-p2p-dial-opts.sh
+++ b/src/dialdbg/test-relay-and-p2p-dial-opts.sh
@@ -4,9 +4,12 @@ set -euo pipefail
 cargo build --features dialdbg --bin viam-dialdbg 2>&1 | tail -1
 BINARY=./target/debug/viam-dialdbg
 
-HOST=""
-ENTITY=""
-APIKEY=""
+HOST="<machine-fqdn>"
+ENTITY="<api-key-id>"
+APIKEY="<api-key>"
+# RELAY_HOST should be a substring matching at least one TURN server URL returned
+# by the signaling server (e.g. "turn.viam.com" for prod coturn).
+RELAY_HOST="<relay-host-substring>"
 COMMON=(-u "$HOST" -e "$ENTITY" -t api-key -c "$APIKEY" --nogrpc --nortt)
 
 PASS=0
@@ -16,7 +19,7 @@ FAIL=0
 # Stats print "local ICE candidate:" followed by fields including "candidate type: <type>".
 # We grab the type value on the line immediately after the local candidate header.
 local_candidate_type() {
-  awk '/\tlocal ICE candidate:/{found=1} found && /candidate type:/{print $NF; found=0}' <<< "$1"
+  awk '/\tlocal ICE candidate:/{found=1} found && /candidate type:/{print $NF; found=0}' <<< "$1" | head -1
 }
 
 assert() {
@@ -73,8 +76,19 @@ assert "baseline (no flags)" "$(run)" "!relay"
 # 2. ForceRelay — expect relay
 assert "ForceRelay" "$(run --force-relay)" "relay"
 
-# 3. ForceP2P — expect non-relay (host or srflx)
+# 3. ForceRelay + RelayHostFilter matching a valid TURN server — expect relay
+assert "ForceRelay + RelayHostFilter" "$(run --force-relay --relay-host-filter "$RELAY_HOST")" "relay"
+
+# 4. ForceP2P — expect non-relay (host or srflx)
 assert "ForceP2P" "$(run --force-p2p)" "!relay"
+
+# 5. RelayHostFilter alone — filter limits TURN options but ICE still picks
+# host/srflx; expect non-relay
+assert "RelayHostFilter (no ForceRelay)" "$(run --relay-host-filter "$RELAY_HOST")" "!relay"
+
+# 6. ForceRelay + non-matching RelayHostFilter — all TURN filtered out,
+# no relay candidates, expect failure
+assert "ForceRelay + RelayHostFilter=notexist (expect: fail)" "$(run --force-relay --relay-host-filter notexist.example.com)" "none"
 
 printf '\n%d passed, %d failed.\n' "$PASS" "$FAIL"
 [[ $FAIL -eq 0 ]]

--- a/src/dialdbg/test-relay-and-p2p-dial-opts.sh
+++ b/src/dialdbg/test-relay-and-p2p-dial-opts.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cargo build --features dialdbg --bin viam-dialdbg 2>&1 | tail -1
+BINARY=./target/debug/viam-dialdbg
+
+HOST="machine-main.ozy75nuoux.viam.cloud"
+ENTITY="4f04c6ca-b9df-440d-82db-6d383b0c92a1"
+APIKEY="ymw99jc6h6ki2m9rlhzekp8r2tpj9zjy"
+COMMON=(-u "$HOST" -e "$ENTITY" -t api-key -c "$APIKEY" --nogrpc --nortt)
+
+PASS=0
+FAIL=0
+
+# Extract the local ICE candidate type from dialdbg output.
+# Stats print "local ICE candidate:" followed by fields including "candidate type: <type>".
+# We grab the type value on the line immediately after the local candidate header.
+local_candidate_type() {
+  awk '/\tlocal ICE candidate:/{found=1} found && /candidate type:/{print $NF; found=0}' <<< "$1"
+}
+
+assert() {
+  local name="$1" output="$2" want_type="$3"  # want_type: "relay", "!relay", or "none"
+  printf '\n=== %s ===\n' "$name"
+  printf '%s\n' "$output"
+
+  local actual
+  actual=$(local_candidate_type "$output")
+
+  if [[ "$want_type" == "none" ]]; then
+    # Expect connection failure — no candidates should be nominated.
+    if [[ -z "$actual" ]]; then
+      printf 'PASS: no candidates nominated (expected failure)\n'
+      ((++PASS))
+    else
+      printf 'FAIL: expected no candidates, got local candidate type: %s\n' "$actual"
+      ((++FAIL))
+    fi
+  elif [[ "$want_type" == "!relay" ]]; then
+    # Expect a successful non-relay connection.
+    if [[ -n "$actual" && "$actual" != "relay" ]]; then
+      printf 'PASS: local candidate type: %s (not relay)\n' "$actual"
+      ((++PASS))
+    elif [[ -z "$actual" ]]; then
+      printf 'FAIL: connection failed (no candidates nominated)\n'
+      ((++FAIL))
+    else
+      printf 'FAIL: expected non-relay candidate, got: %s\n' "$actual"
+      ((++FAIL))
+    fi
+  else
+    # Expect a specific candidate type (e.g. "relay").
+    if [[ "$actual" == "$want_type" ]]; then
+      printf 'PASS: local candidate type: %s\n' "$actual"
+      ((++PASS))
+    elif [[ -z "$actual" ]]; then
+      printf 'FAIL: connection failed (no candidates nominated)\n'
+      ((++FAIL))
+    else
+      printf 'FAIL: expected candidate type %s, got: %s\n' "$want_type" "$actual"
+      ((++FAIL))
+    fi
+  fi
+}
+
+run() {
+  "$BINARY" "${COMMON[@]}" "$@" 2>/dev/null || true
+}
+
+# 1. Baseline — expect non-relay (host or srflx)
+assert "baseline (no flags)" "$(run)" "!relay"
+
+# 2. ForceRelay — expect relay
+assert "ForceRelay" "$(run --force-relay)" "relay"
+
+# 3. ForceP2P — expect non-relay (host or srflx)
+assert "ForceP2P" "$(run --force-p2p)" "!relay"
+
+printf '\n%d passed, %d failed.\n' "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]]

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -350,7 +350,6 @@ impl<T: AuthMethod> DialBuilder<T> {
     }
 
     /// Overrides the signaling server address used for WebRTC negotiation.
-    /// Useful for testing against a specific app deployment (e.g. a Cloud Run PR deploy).
     pub fn signaling_server(mut self, address: String) -> Self {
         self.config.signaling_server_override = Some(address);
         self

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -785,21 +785,13 @@ impl DialBuilder<WithCredentials> {
                 HeaderName::from_static("rpc-host"),
                 HeaderValue::from_str(domain.as_str())?,
             ))
-            .service(real_channel.clone());
-
-        let signaling_channel = ServiceBuilder::new()
-            .layer(AddAuthorizationLayer::bearer(&token))
-            .layer(SetRequestHeaderLayer::overriding(
-                HeaderName::from_static("rpc-host"),
-                HeaderValue::from_str(domain.as_str())?,
-            ))
             .service(real_channel);
 
         if disable_webrtc {
             log::debug!("Connected via gRPC");
             Ok(ViamChannel::DirectPreAuthorized(channel))
         } else {
-            match maybe_connect_via_webrtc(original_uri, signaling_channel, webrtc_options).await {
+            match maybe_connect_via_webrtc(original_uri, channel.clone(), webrtc_options).await {
                 Ok(webrtc_channel) => Ok(ViamChannel::WebRTC(webrtc_channel)),
                 Err(e) => {
                     log::error!(

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -432,8 +432,6 @@ impl<T: AuthMethod> DialBuilder<T> {
 
     async fn get_mdns_uri(&self) -> Option<Parts> {
         log::debug!("{}", log_prefixes::MDNS_QUERY_ATTEMPT);
-        return None;
-
         let mut uri = self.duplicate_uri()?;
         let candidate = uri.authority.clone()?.to_string();
 
@@ -495,10 +493,14 @@ impl<T: AuthMethod> DialBuilder<T> {
         {
             Ok(c) => c,
             Err(e) => {
-                let mut uri_parts = uri.clone().into_parts();
-                uri_parts.scheme = Some(Scheme::HTTP);
-                let uri = Uri::from_parts(uri_parts)?;
-                Channel::builder(uri).connect().await?
+                if allow_downgrade {
+                    let mut uri_parts = uri.clone().into_parts();
+                    uri_parts.scheme = Some(Scheme::HTTP);
+                    let uri = Uri::from_parts(uri_parts)?;
+                    Channel::builder(uri).connect().await?
+                } else {
+                    return Err(anyhow::anyhow!(e));
+                }
             }
         };
         Ok(chan)
@@ -571,12 +573,13 @@ impl DialBuilder<WithoutCredentials> {
             }
         };
 
-        let signaling_channel = if let Some(ref override_addr) = self.config.signaling_server_override {
-            let override_uri = Uri::from_parts(uri_parts_with_defaults(override_addr))?;
-            let override_domain = override_uri.clone().authority().map(|a| a.as_str().to_string()).unwrap_or_else(|| override_addr.clone());
-            Self::create_channel(self.config.allow_downgrade, &override_domain, override_uri, false).await?
-        } else {
-            channel.clone()
+        let signaling_channel = match self.config.signaling_server_override.as_deref() {
+            Some(addr) => {
+                let uri = Uri::from_parts(uri_parts_with_defaults(addr))?;
+                let signaling_domain = uri.authority().map(|a| a.host().to_string()).unwrap_or_else(|| addr.to_string());
+                Self::create_channel(self.config.allow_downgrade, &signaling_domain, uri, false).await?
+            }
+            None => channel.clone(),
         };
 
         // TODO (RSDK-517) make maybe_connect_via_webrtc take a more generic type so we don't
@@ -628,9 +631,12 @@ impl DialBuilder<WithoutCredentials> {
         let original_uri2 = duplicate_uri(&original_uri).ok_or(anyhow::anyhow!(
             "Attempting to connect but there was no uri"
         ))?;
-        if self.config.disable_mdns {
-            return self.connect_inner(None, original_uri).await;
-        }
+        let skip_mdns = self.config.disable_mdns
+            || self
+                .config
+                .webrtc_options
+                .as_ref()
+                .map_or(false, |o| o.force_relay);
 
         // We want to short circuit and return the first `Ok` result from our connection
         // attempts, which `tokio::select!` does great. Buuuuut, we don't want to
@@ -638,11 +644,14 @@ impl DialBuilder<WithoutCredentials> {
         // debugging purposes. Hence the loop and pinning. The pinning lets us reference
         // the same future multiple times, while the loop lets us immediately return on the
         // first `Ok` result while still seeing and logging any error results.
+        //
+        // When mDNS is skipped (disable_mdns or force_relay), with_mdns_err is pre-set so
+        // the select guard disables that branch and only the direct connection is attempted.
         tokio::pin! {
             let with_mdns = self.clone().connect_mdns(original_uri);
             let without_mdns = self.connect_inner(None, original_uri2);
         }
-        let mut with_mdns_err: Option<anyhow::Error> = None;
+        let mut with_mdns_err: Option<anyhow::Error> = skip_mdns.then(|| anyhow::anyhow!("mDNS skipped"));
         let mut without_mdns_err: Option<anyhow::Error> = None;
         while with_mdns_err.is_none() || without_mdns_err.is_none() {
             tokio::select! {
@@ -757,25 +766,21 @@ impl DialBuilder<WithCredentials> {
             }
         };
 
-        // Build the signaling channel first so we can authenticate against it when an override
-        // is set. This ensures the token is valid for the signaling server's auth (e.g. when
-        // pointing at a local app server that validates tokens differently from the robot).
-        let signaling_real_channel = if let Some(ref override_addr) = self.config.signaling_server_override {
-            let override_uri = Uri::from_parts(uri_parts_with_defaults(override_addr))?;
-            let override_domain = override_uri.authority().map(|a| a.as_str().to_string()).unwrap_or_else(|| override_addr.clone());
-            Self::create_channel(allow_downgrade, &override_domain, override_uri, false).await?
-        } else {
-            real_channel.clone()
+        // When a signaling server override is set, authenticate against it rather than the
+        // robot channel — the override server (e.g. a local app instance) validates tokens
+        // independently and the robot's token would be rejected.
+        let signaling_raw_channel = match self.config.signaling_server_override.as_deref() {
+            Some(addr) => {
+                let uri = Uri::from_parts(uri_parts_with_defaults(addr))?;
+                let signaling_domain = uri.authority().map(|a| a.host().to_string()).unwrap_or_else(|| addr.to_string());
+                Self::create_channel(allow_downgrade, &signaling_domain, uri, false).await?
+            }
+            None => real_channel.clone(),
         };
 
         log::debug!("{}", log_prefixes::ACQUIRING_AUTH_TOKEN);
-        let auth_channel = if self.config.signaling_server_override.is_some() {
-            signaling_real_channel.clone()
-        } else {
-            real_channel.clone()
-        };
         let token = get_auth_token(
-            &mut auth_channel.clone(),
+            &mut signaling_raw_channel.clone(),
             self.config
                 .credentials
                 .as_ref()
@@ -805,7 +810,7 @@ impl DialBuilder<WithCredentials> {
                 HeaderName::from_static("rpc-host"),
                 HeaderValue::from_str(domain.as_str())?,
             ))
-            .service(signaling_real_channel);
+            .service(signaling_raw_channel);
 
         if disable_webrtc {
             log::debug!("Connected via gRPC");
@@ -851,9 +856,12 @@ impl DialBuilder<WithCredentials> {
             "Attempting to connect but there was no uri"
         ))?;
 
-        if self.config.disable_mdns {
-            return self.connect_inner(None, original_uri).await;
-        }
+        let skip_mdns = self.config.disable_mdns
+            || self
+                .config
+                .webrtc_options
+                .as_ref()
+                .map_or(false, |o| o.force_relay);
 
         // We want to short circuit and return the first `Ok` result from our connection
         // attempts, which `tokio::select!` does great. Buuuuut, we don't want to
@@ -861,11 +869,14 @@ impl DialBuilder<WithCredentials> {
         // debugging purposes. Hence the loop and pinning. The pinning lets us reference
         // the same future multiple times, while the loop lets us immediately return on the
         // first `Ok` result while still seeing and logging any error results.
+        //
+        // When mDNS is skipped (disable_mdns or force_relay), with_mdns_err is pre-set so
+        // the select guard disables that branch and only the direct connection is attempted.
         tokio::pin! {
             let with_mdns = self.clone().connect_mdns(original_uri);
             let without_mdns = self.connect_inner(None, original_uri2);
         }
-        let mut with_mdns_err: Option<anyhow::Error> = None;
+        let mut with_mdns_err: Option<anyhow::Error> = skip_mdns.then(|| anyhow::anyhow!("mDNS skipped"));
         let mut without_mdns_err: Option<anyhow::Error> = None;
         while with_mdns_err.is_none() || without_mdns_err.is_none() {
             tokio::select! {

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -338,6 +338,17 @@ impl<T: AuthMethod> DialBuilder<T> {
         self
     }
 
+    /// Filters the assembled ICE server list to only TURN servers whose URL contains
+    /// the given substring. Can be combined with force_relay to route through a specific
+    /// TURN server.
+    pub fn relay_host_filter(mut self, host: String) -> Self {
+        self.config
+            .webrtc_options
+            .get_or_insert_with(Options::default)
+            .relay_host_filter = Some(host);
+        self
+    }
+
     /// Overrides the signaling server address used for WebRTC negotiation.
     /// Useful for testing against a specific app deployment (e.g. a Cloud Run PR deploy).
     pub fn signaling_server(mut self, address: String) -> Self {
@@ -970,7 +981,10 @@ async fn maybe_connect_via_webrtc(
         webrtc_options.force_relay,
         webrtc_options.force_p2p,
     );
-    let config = webrtc::extend_webrtc_config(base_config, optional_config);
+    let mut config = webrtc::extend_webrtc_config(base_config, optional_config);
+    if let Some(ref host) = webrtc_options.relay_host_filter {
+        config = webrtc::filter_ice_servers_by_host(config, host);
+    }
 
     let (peer_connection, data_channel) =
         webrtc::new_peer_connection_for_client(config, webrtc_options.disable_trickle_ice).await?;

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -547,7 +547,7 @@ impl DialBuilder<WithoutCredentials> {
             original_uri,
             self.config.signaling_server_override.as_deref(),
         );
-        let domain = uri2.authority().to_owned().unwrap().host().to_owned();
+        let domain = uri2.authority().to_owned().unwrap().as_str();
 
         let mdns_uri = mdns_uri.and_then(|p| Uri::from_parts(p).ok());
         let attempting_mdns = mdns_uri.is_some();
@@ -559,7 +559,7 @@ impl DialBuilder<WithoutCredentials> {
 
         let channel = match mdns_uri {
             Some(uri) => {
-                Self::create_channel(self.config.allow_downgrade, &domain, uri, true).await
+                Self::create_channel(self.config.allow_downgrade, domain, uri, true).await
             }
             // not actually an error necessarily, but we want to ensure that a channel is still
             // created with the default uri
@@ -577,7 +577,7 @@ impl DialBuilder<WithoutCredentials> {
                         "Unable to connect via mDNS; falling back to robot URI. Error: {e}"
                     );
                 }
-                Self::create_channel(self.config.allow_downgrade, &domain, uri.clone(), false)
+                Self::create_channel(self.config.allow_downgrade, domain, uri.clone(), false)
                     .await?
             }
         };
@@ -591,7 +591,7 @@ impl DialBuilder<WithoutCredentials> {
             ))
             .layer(SetRequestHeaderLayer::overriding(
                 HeaderName::from_static("rpc-host"),
-                HeaderValue::from_str(&domain)?,
+                HeaderValue::from_str(domain)?,
             ))
             .service(channel.clone());
 
@@ -730,7 +730,7 @@ impl DialBuilder<WithCredentials> {
 
         let original_uri = Uri::from_parts(original_uri_parts)?;
 
-        let domain = original_uri.authority().unwrap().host().to_string();
+        let domain = original_uri.authority().unwrap().to_string();
         let uri_for_auth = infer_remote_uri_from_authority(
             original_uri.clone(),
             self.config.signaling_server_override.as_deref(),
@@ -984,13 +984,31 @@ async fn maybe_connect_via_webrtc(
     };
 
     let optional_config = response.into_inner().config;
+
+    if webrtc_options.force_relay && webrtc_options.force_p2p {
+        log::warn!("force_relay and force_p2p are both set; forceP2P strips TURN servers that forceRelay requires so the connection will fail");
+    }
+
     let (base_config, optional_config) = webrtc::apply_ice_policy(
         webrtc_options.config,
         optional_config,
         webrtc_options.force_relay,
         webrtc_options.force_p2p,
     );
+
+    if webrtc_options.force_relay {
+        log::debug!("force relay enabled; using relay-only ICE transport policy");
+    }
+
+    if webrtc_options.force_p2p {
+        log::debug!("force P2P enabled; stripping TURN servers and ignoring signaling server ICE config");
+    }
+
     let mut config = webrtc::extend_webrtc_config(base_config, optional_config);
+    
+    if webrtc_options.force_p2p && webrtc_options.turn_uri.is_some() {
+        log::warn!("force_p2p is set alongside turn_uri; the TURN filter will have no effect since TURN servers were already stripped");
+    }
     let turn_uri = webrtc_options.turn_uri.as_deref().and_then(|s| {
         let parsed = webrtc::TurnUri::parse(s);
         if parsed.is_none() {
@@ -999,6 +1017,9 @@ async fn maybe_connect_via_webrtc(
         parsed
     });
     config = webrtc::apply_turn_options(config, turn_uri.as_ref());
+    if let Some(ref uri) = turn_uri {
+        log::debug!("TURN filter options set: turn_uri={uri:?}");
+    }
 
     let (peer_connection, data_channel) =
         webrtc::new_peer_connection_for_client(config, webrtc_options.disable_trickle_ice).await?;

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -435,7 +435,7 @@ impl<T: AuthMethod> DialBuilder<T> {
         if self.config.disable_mdns {
             return None;
         }
-        
+
         let mut uri = self.duplicate_uri()?;
         let candidate = uri.authority.clone()?.to_string();
 

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -338,16 +338,6 @@ impl<T: AuthMethod> DialBuilder<T> {
         self
     }
 
-    /// Retains only ICE servers whose URLs contain the given host string, applied after
-    /// the full ICE server list is assembled. Useful for isolating a specific TURN server.
-    pub fn relay_host_filter(mut self, host: String) -> Self {
-        self.config
-            .webrtc_options
-            .get_or_insert_with(Options::default)
-            .relay_host_filter = Some(host);
-        self
-    }
-
     /// Overrides the signaling server address used for WebRTC negotiation.
     /// Useful for testing against a specific app deployment (e.g. a Cloud Run PR deploy).
     pub fn signaling_server(mut self, address: String) -> Self {
@@ -989,10 +979,7 @@ async fn maybe_connect_via_webrtc(
         webrtc_options.force_relay,
         webrtc_options.force_p2p,
     );
-    let mut config = webrtc::extend_webrtc_config(base_config, optional_config);
-    if let Some(host) = &webrtc_options.relay_host_filter {
-        config = webrtc::filter_ice_servers_by_host(config, host);
-    }
+    let config = webrtc::extend_webrtc_config(base_config, optional_config);
 
     let (peer_connection, data_channel) =
         webrtc::new_peer_connection_for_client(config, webrtc_options.disable_trickle_ice).await?;

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -631,7 +631,7 @@ impl DialBuilder<WithoutCredentials> {
                 .config
                 .webrtc_options
                 .as_ref()
-                .map_or(false, |o| o.force_relay);
+                .is_some_and(|o| o.force_relay);
 
         // We want to short circuit and return the first `Ok` result from our connection
         // attempts, which `tokio::select!` does great. Buuuuut, we don't want to
@@ -836,7 +836,7 @@ impl DialBuilder<WithCredentials> {
                 .config
                 .webrtc_options
                 .as_ref()
-                .map_or(false, |o| o.force_relay);
+                .is_some_and(|o| o.force_relay);
 
         // We want to short circuit and return the first `Ok` result from our connection
         // attempts, which `tokio::select!` does great. Buuuuut, we don't want to

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -543,7 +543,10 @@ impl DialBuilder<WithoutCredentials> {
         }
         let original_uri = Uri::from_parts(original_uri_parts)?;
         let uri2 = original_uri.clone();
-        let uri = infer_remote_uri_from_authority(original_uri, self.config.signaling_server_override.as_deref());
+        let uri = infer_remote_uri_from_authority(
+            original_uri,
+            self.config.signaling_server_override.as_deref(),
+        );
         let domain = uri2.authority().to_owned().unwrap().host().to_owned();
 
         let mdns_uri = mdns_uri.and_then(|p| Uri::from_parts(p).ok());
@@ -555,7 +558,9 @@ impl DialBuilder<WithoutCredentials> {
         }
 
         let channel = match mdns_uri {
-            Some(uri) => Self::create_channel(self.config.allow_downgrade, &domain, uri, true).await,
+            Some(uri) => {
+                Self::create_channel(self.config.allow_downgrade, &domain, uri, true).await
+            }
             // not actually an error necessarily, but we want to ensure that a channel is still
             // created with the default uri
             None => Err(anyhow::anyhow!("")),
@@ -642,7 +647,8 @@ impl DialBuilder<WithoutCredentials> {
             let with_mdns = self.clone().connect_mdns(original_uri);
             let without_mdns = self.connect_inner(None, original_uri2);
         }
-        let mut with_mdns_err: Option<anyhow::Error> = skip_mdns.then(|| anyhow::anyhow!("mDNS skipped"));
+        let mut with_mdns_err: Option<anyhow::Error> =
+            skip_mdns.then(|| anyhow::anyhow!("mDNS skipped"));
         let mut without_mdns_err: Option<anyhow::Error> = None;
         while with_mdns_err.is_none() || without_mdns_err.is_none() {
             tokio::select! {
@@ -725,7 +731,10 @@ impl DialBuilder<WithCredentials> {
         let original_uri = Uri::from_parts(original_uri_parts)?;
 
         let domain = original_uri.authority().unwrap().host().to_string();
-        let uri_for_auth = infer_remote_uri_from_authority(original_uri.clone(), self.config.signaling_server_override.as_deref());
+        let uri_for_auth = infer_remote_uri_from_authority(
+            original_uri.clone(),
+            self.config.signaling_server_override.as_deref(),
+        );
 
         let mdns_uri = mdns_uri.and_then(|p| Uri::from_parts(p).ok());
         let attempting_mdns = mdns_uri.is_some();
@@ -842,7 +851,8 @@ impl DialBuilder<WithCredentials> {
             let with_mdns = self.clone().connect_mdns(original_uri);
             let without_mdns = self.connect_inner(None, original_uri2);
         }
-        let mut with_mdns_err: Option<anyhow::Error> = skip_mdns.then(|| anyhow::anyhow!("mDNS skipped"));
+        let mut with_mdns_err: Option<anyhow::Error> =
+            skip_mdns.then(|| anyhow::anyhow!("mDNS skipped"));
         let mut without_mdns_err: Option<anyhow::Error> = None;
         while with_mdns_err.is_none() || without_mdns_err.is_none() {
             tokio::select! {

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -432,6 +432,10 @@ impl<T: AuthMethod> DialBuilder<T> {
 
     async fn get_mdns_uri(&self) -> Option<Parts> {
         log::debug!("{}", log_prefixes::MDNS_QUERY_ATTEMPT);
+        if self.config.disable_mdns {
+            return None;
+        }
+        
         let mut uri = self.duplicate_uri()?;
         let candidate = uri.authority.clone()?.to_string();
 
@@ -539,7 +543,7 @@ impl DialBuilder<WithoutCredentials> {
         }
         let original_uri = Uri::from_parts(original_uri_parts)?;
         let uri2 = original_uri.clone();
-        let uri = infer_remote_uri_from_authority(original_uri);
+        let uri = infer_remote_uri_from_authority(original_uri, self.config.signaling_server_override.as_deref());
         let domain = uri2.authority().to_owned().unwrap().host().to_owned();
 
         let mdns_uri = mdns_uri.and_then(|p| Uri::from_parts(p).ok());
@@ -573,15 +577,6 @@ impl DialBuilder<WithoutCredentials> {
             }
         };
 
-        let signaling_channel = match self.config.signaling_server_override.as_deref() {
-            Some(addr) => {
-                let uri = Uri::from_parts(uri_parts_with_defaults(addr))?;
-                let signaling_domain = uri.authority().map(|a| a.host().to_string()).unwrap_or_else(|| addr.to_string());
-                Self::create_channel(self.config.allow_downgrade, &signaling_domain, uri, false).await?
-            }
-            None => channel.clone(),
-        };
-
         // TODO (RSDK-517) make maybe_connect_via_webrtc take a more generic type so we don't
         // need to add these dummy layers.
         let intercepted_channel = ServiceBuilder::new()
@@ -593,7 +588,7 @@ impl DialBuilder<WithoutCredentials> {
                 HeaderName::from_static("rpc-host"),
                 HeaderValue::from_str(&domain)?,
             ))
-            .service(signaling_channel);
+            .service(channel.clone());
 
         if disable_webrtc {
             log::debug!("{}", log_prefixes::DIALED_GRPC);
@@ -734,7 +729,7 @@ impl DialBuilder<WithCredentials> {
         let original_uri = Uri::from_parts(original_uri_parts)?;
 
         let domain = original_uri.authority().unwrap().host().to_string();
-        let uri_for_auth = infer_remote_uri_from_authority(original_uri.clone());
+        let uri_for_auth = infer_remote_uri_from_authority(original_uri.clone(), self.config.signaling_server_override.as_deref());
 
         let mdns_uri = mdns_uri.and_then(|p| Uri::from_parts(p).ok());
         let attempting_mdns = mdns_uri.is_some();
@@ -766,21 +761,9 @@ impl DialBuilder<WithCredentials> {
             }
         };
 
-        // When a signaling server override is set, authenticate against it rather than the
-        // robot channel — the override server (e.g. a local app instance) validates tokens
-        // independently and the robot's token would be rejected.
-        let signaling_raw_channel = match self.config.signaling_server_override.as_deref() {
-            Some(addr) => {
-                let uri = Uri::from_parts(uri_parts_with_defaults(addr))?;
-                let signaling_domain = uri.authority().map(|a| a.host().to_string()).unwrap_or_else(|| addr.to_string());
-                Self::create_channel(allow_downgrade, &signaling_domain, uri, false).await?
-            }
-            None => real_channel.clone(),
-        };
-
         log::debug!("{}", log_prefixes::ACQUIRING_AUTH_TOKEN);
         let token = get_auth_token(
-            &mut signaling_raw_channel.clone(),
+            &mut real_channel.clone(),
             self.config
                 .credentials
                 .as_ref()
@@ -802,7 +785,7 @@ impl DialBuilder<WithCredentials> {
                 HeaderName::from_static("rpc-host"),
                 HeaderValue::from_str(domain.as_str())?,
             ))
-            .service(real_channel);
+            .service(real_channel.clone());
 
         let signaling_channel = ServiceBuilder::new()
             .layer(AddAuthorizationLayer::bearer(&token))
@@ -810,7 +793,7 @@ impl DialBuilder<WithCredentials> {
                 HeaderName::from_static("rpc-host"),
                 HeaderValue::from_str(domain.as_str())?,
             ))
-            .service(signaling_raw_channel);
+            .service(real_channel);
 
         if disable_webrtc {
             log::debug!("Connected via gRPC");
@@ -1399,7 +1382,10 @@ fn encode_sdp(sdp: RTCSessionDescription) -> Result<String> {
     Ok(base64::encode(sdp))
 }
 
-fn infer_remote_uri_from_authority(uri: Uri) -> Uri {
+fn infer_remote_uri_from_authority(uri: Uri, override_addr: Option<&str>) -> Uri {
+    if let Some(addr) = override_addr {
+        return Uri::from_parts(uri_parts_with_defaults(addr)).unwrap_or(uri);
+    }
     let authority = uri.authority().map(Authority::as_str).unwrap_or_default();
     let is_local_connection = authority.contains(".local.viam.cloud")
         || authority.contains("localhost")

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -1370,7 +1370,10 @@ fn encode_sdp(sdp: RTCSessionDescription) -> Result<String> {
 
 fn infer_remote_uri_from_authority(uri: Uri, override_addr: Option<&str>) -> Uri {
     if let Some(addr) = override_addr {
-        return Uri::from_parts(uri_parts_with_defaults(addr)).unwrap_or(uri);
+        return Uri::from_parts(uri_parts_with_defaults(addr)).unwrap_or_else(|e| {
+            log::warn!("Failed to parse signaling server override {addr:?}: {e}; falling back to original URI");
+            uri
+        });
     }
     let authority = uri.authority().map(Authority::as_str).unwrap_or_default();
     let is_local_connection = authority.contains(".local.viam.cloud")

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -338,16 +338,17 @@ impl<T: AuthMethod> DialBuilder<T> {
         self
     }
 
-    /// Filters the assembled ICE server list to only TURN servers whose URL contains
-    /// the given substring. Can be combined with force_relay to route through a specific
-    /// TURN server.
-    pub fn relay_host_filter(mut self, host: String) -> Self {
+    /// Filters the signaling server's TURN list to only the server whose parsed URI
+    /// matches. Uses struct comparison identical to the server-side TURN_URI env var.
+    /// Example: "turn:turn.viam.com:443"
+    pub fn turn_uri(mut self, uri: impl Into<String>) -> Self {
         self.config
             .webrtc_options
             .get_or_insert_with(Options::default)
-            .relay_host_filter = Some(host);
+            .turn_uri = Some(uri.into());
         self
     }
+
 
     /// Overrides the signaling server address used for WebRTC negotiation.
     /// Useful for testing against a specific app deployment (e.g. a Cloud Run PR deploy).
@@ -982,9 +983,11 @@ async fn maybe_connect_via_webrtc(
         webrtc_options.force_p2p,
     );
     let mut config = webrtc::extend_webrtc_config(base_config, optional_config);
-    if let Some(ref host) = webrtc_options.relay_host_filter {
-        config = webrtc::filter_ice_servers_by_host(config, host);
-    }
+    let turn_uri = webrtc_options
+        .turn_uri
+        .as_deref()
+        .and_then(webrtc::TurnUri::parse);
+    config = webrtc::apply_turn_options(config, turn_uri.as_ref());
 
     let (peer_connection, data_channel) =
         webrtc::new_peer_connection_for_client(config, webrtc_options.disable_trickle_ice).await?;

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -982,10 +982,13 @@ async fn maybe_connect_via_webrtc(
         webrtc_options.force_p2p,
     );
     let mut config = webrtc::extend_webrtc_config(base_config, optional_config);
-    let turn_uri = webrtc_options
-        .turn_uri
-        .as_deref()
-        .and_then(webrtc::TurnUri::parse);
+    let turn_uri = webrtc_options.turn_uri.as_deref().and_then(|s| {
+        let parsed = webrtc::TurnUri::parse(s);
+        if parsed.is_none() {
+            log::warn!("Failed to parse turn_uri, ignoring: {s:?}");
+        }
+        parsed
+    });
     config = webrtc::apply_turn_options(config, turn_uri.as_ref());
 
     let (peer_connection, data_channel) =

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -193,6 +193,7 @@ pub struct DialOptions {
     disable_mdns: bool,
     allow_downgrade: bool,
     insecure: bool,
+    signaling_server_override: Option<String>,
 }
 #[derive(Clone)]
 pub struct WantsCredentials(());
@@ -234,6 +235,7 @@ impl DialOptions {
                 disable_mdns: false,
                 insecure: false,
                 webrtc_options: None,
+                signaling_server_override: None,
             },
         }
     }
@@ -252,6 +254,7 @@ impl DialBuilder<WantsUri> {
                 disable_mdns: false,
                 insecure: false,
                 webrtc_options: None,
+                signaling_server_override: None,
             },
         }
     }
@@ -268,6 +271,7 @@ impl DialBuilder<WantsCredentials> {
                 disable_mdns: false,
                 insecure: false,
                 webrtc_options: None,
+                signaling_server_override: None,
             },
         }
     }
@@ -282,6 +286,7 @@ impl DialBuilder<WantsCredentials> {
                 disable_mdns: false,
                 insecure: false,
                 webrtc_options: None,
+                signaling_server_override: None,
             },
         }
     }
@@ -310,6 +315,43 @@ impl<T: AuthMethod> DialBuilder<T> {
     pub fn disable_webrtc(mut self) -> Self {
         let webrtc_options = Options::default().disable_webrtc();
         self.config.webrtc_options = Some(webrtc_options);
+        self
+    }
+
+    /// Forces ICE transport policy to relay-only so only TURN candidates are used.
+    /// Useful for testing relay connectivity through a TURN server.
+    pub fn force_relay(mut self) -> Self {
+        self.config
+            .webrtc_options
+            .get_or_insert_with(Options::default)
+            .force_relay = true;
+        self
+    }
+
+    /// Strips TURN servers from the ICE config so only host and server-reflexive
+    /// candidates are used. Useful for testing direct connectivity without relay fallback.
+    pub fn force_p2p(mut self) -> Self {
+        self.config
+            .webrtc_options
+            .get_or_insert_with(Options::default)
+            .force_p2p = true;
+        self
+    }
+
+    /// Retains only ICE servers whose URLs contain the given host string, applied after
+    /// the full ICE server list is assembled. Useful for isolating a specific TURN server.
+    pub fn relay_host_filter(mut self, host: String) -> Self {
+        self.config
+            .webrtc_options
+            .get_or_insert_with(Options::default)
+            .relay_host_filter = Some(host);
+        self
+    }
+
+    /// Overrides the signaling server address used for WebRTC negotiation.
+    /// Useful for testing against a specific app deployment (e.g. a Cloud Run PR deploy).
+    pub fn signaling_server(mut self, address: String) -> Self {
+        self.config.signaling_server_override = Some(address);
         self
     }
 
@@ -390,9 +432,7 @@ impl<T: AuthMethod> DialBuilder<T> {
 
     async fn get_mdns_uri(&self) -> Option<Parts> {
         log::debug!("{}", log_prefixes::MDNS_QUERY_ATTEMPT);
-        if self.config.disable_mdns {
-            return None;
-        }
+        return None;
 
         let mut uri = self.duplicate_uri()?;
         let candidate = uri.authority.clone()?.to_string();
@@ -455,14 +495,10 @@ impl<T: AuthMethod> DialBuilder<T> {
         {
             Ok(c) => c,
             Err(e) => {
-                if allow_downgrade {
-                    let mut uri_parts = uri.clone().into_parts();
-                    uri_parts.scheme = Some(Scheme::HTTP);
-                    let uri = Uri::from_parts(uri_parts)?;
-                    Channel::builder(uri).connect().await?
-                } else {
-                    return Err(anyhow::anyhow!(e));
-                }
+                let mut uri_parts = uri.clone().into_parts();
+                uri_parts.scheme = Some(Scheme::HTTP);
+                let uri = Uri::from_parts(uri_parts)?;
+                Channel::builder(uri).connect().await?
             }
         };
         Ok(chan)
@@ -480,6 +516,7 @@ impl DialBuilder<WithoutCredentials> {
                 disable_mdns: self.config.disable_mdns,
                 allow_downgrade: self.config.allow_downgrade,
                 insecure: self.config.insecure,
+                signaling_server_override: self.config.signaling_server_override.clone(),
             },
         }
     }
@@ -501,7 +538,7 @@ impl DialBuilder<WithoutCredentials> {
         let original_uri = Uri::from_parts(original_uri_parts)?;
         let uri2 = original_uri.clone();
         let uri = infer_remote_uri_from_authority(original_uri);
-        let domain = uri2.authority().to_owned().unwrap().as_str();
+        let domain = uri2.authority().to_owned().unwrap().host().to_owned();
 
         let mdns_uri = mdns_uri.and_then(|p| Uri::from_parts(p).ok());
         let attempting_mdns = mdns_uri.is_some();
@@ -512,7 +549,7 @@ impl DialBuilder<WithoutCredentials> {
         }
 
         let channel = match mdns_uri {
-            Some(uri) => Self::create_channel(self.config.allow_downgrade, domain, uri, true).await,
+            Some(uri) => Self::create_channel(self.config.allow_downgrade, &domain, uri, true).await,
             // not actually an error necessarily, but we want to ensure that a channel is still
             // created with the default uri
             None => Err(anyhow::anyhow!("")),
@@ -529,10 +566,19 @@ impl DialBuilder<WithoutCredentials> {
                         "Unable to connect via mDNS; falling back to robot URI. Error: {e}"
                     );
                 }
-                Self::create_channel(self.config.allow_downgrade, domain, uri.clone(), false)
+                Self::create_channel(self.config.allow_downgrade, &domain, uri.clone(), false)
                     .await?
             }
         };
+
+        let signaling_channel = if let Some(ref override_addr) = self.config.signaling_server_override {
+            let override_uri = Uri::from_parts(uri_parts_with_defaults(override_addr))?;
+            let override_domain = override_uri.clone().authority().map(|a| a.as_str().to_string()).unwrap_or_else(|| override_addr.clone());
+            Self::create_channel(self.config.allow_downgrade, &override_domain, override_uri, false).await?
+        } else {
+            channel.clone()
+        };
+
         // TODO (RSDK-517) make maybe_connect_via_webrtc take a more generic type so we don't
         // need to add these dummy layers.
         let intercepted_channel = ServiceBuilder::new()
@@ -542,9 +588,9 @@ impl DialBuilder<WithoutCredentials> {
             ))
             .layer(SetRequestHeaderLayer::overriding(
                 HeaderName::from_static("rpc-host"),
-                HeaderValue::from_str(domain)?,
+                HeaderValue::from_str(&domain)?,
             ))
-            .service(channel.clone());
+            .service(signaling_channel);
 
         if disable_webrtc {
             log::debug!("{}", log_prefixes::DIALED_GRPC);
@@ -582,6 +628,10 @@ impl DialBuilder<WithoutCredentials> {
         let original_uri2 = duplicate_uri(&original_uri).ok_or(anyhow::anyhow!(
             "Attempting to connect but there was no uri"
         ))?;
+        if self.config.disable_mdns {
+            return self.connect_inner(None, original_uri).await;
+        }
+
         // We want to short circuit and return the first `Ok` result from our connection
         // attempts, which `tokio::select!` does great. Buuuuut, we don't want to
         // abandon the `Err` results, and we want to provide comprehensive logging for
@@ -650,6 +700,7 @@ impl DialBuilder<WithCredentials> {
                 disable_mdns: self.config.disable_mdns,
                 allow_downgrade: self.config.allow_downgrade,
                 insecure: self.config.insecure,
+                signaling_server_override: self.config.signaling_server_override.clone(),
             },
         }
     }
@@ -673,7 +724,7 @@ impl DialBuilder<WithCredentials> {
 
         let original_uri = Uri::from_parts(original_uri_parts)?;
 
-        let domain = original_uri.authority().unwrap().to_string();
+        let domain = original_uri.authority().unwrap().host().to_string();
         let uri_for_auth = infer_remote_uri_from_authority(original_uri.clone());
 
         let mdns_uri = mdns_uri.and_then(|p| Uri::from_parts(p).ok());
@@ -706,9 +757,25 @@ impl DialBuilder<WithCredentials> {
             }
         };
 
+        // Build the signaling channel first so we can authenticate against it when an override
+        // is set. This ensures the token is valid for the signaling server's auth (e.g. when
+        // pointing at a local app server that validates tokens differently from the robot).
+        let signaling_real_channel = if let Some(ref override_addr) = self.config.signaling_server_override {
+            let override_uri = Uri::from_parts(uri_parts_with_defaults(override_addr))?;
+            let override_domain = override_uri.authority().map(|a| a.as_str().to_string()).unwrap_or_else(|| override_addr.clone());
+            Self::create_channel(allow_downgrade, &override_domain, override_uri, false).await?
+        } else {
+            real_channel.clone()
+        };
+
         log::debug!("{}", log_prefixes::ACQUIRING_AUTH_TOKEN);
+        let auth_channel = if self.config.signaling_server_override.is_some() {
+            signaling_real_channel.clone()
+        } else {
+            real_channel.clone()
+        };
         let token = get_auth_token(
-            &mut real_channel.clone(),
+            &mut auth_channel.clone(),
             self.config
                 .credentials
                 .as_ref()
@@ -732,11 +799,19 @@ impl DialBuilder<WithCredentials> {
             ))
             .service(real_channel);
 
+        let signaling_channel = ServiceBuilder::new()
+            .layer(AddAuthorizationLayer::bearer(&token))
+            .layer(SetRequestHeaderLayer::overriding(
+                HeaderName::from_static("rpc-host"),
+                HeaderValue::from_str(domain.as_str())?,
+            ))
+            .service(signaling_real_channel);
+
         if disable_webrtc {
             log::debug!("Connected via gRPC");
             Ok(ViamChannel::DirectPreAuthorized(channel))
         } else {
-            match maybe_connect_via_webrtc(original_uri, channel.clone(), webrtc_options).await {
+            match maybe_connect_via_webrtc(original_uri, signaling_channel, webrtc_options).await {
                 Ok(webrtc_channel) => Ok(ViamChannel::WebRTC(webrtc_channel)),
                 Err(e) => {
                     log::error!(
@@ -775,6 +850,10 @@ impl DialBuilder<WithCredentials> {
         let original_uri2 = duplicate_uri(&original_uri).ok_or(anyhow::anyhow!(
             "Attempting to connect but there was no uri"
         ))?;
+
+        if self.config.disable_mdns {
+            return self.connect_inner(None, original_uri).await;
+        }
 
         // We want to short circuit and return the first `Ok` result from our connection
         // attempts, which `tokio::select!` does great. Buuuuut, we don't want to
@@ -918,7 +997,16 @@ async fn maybe_connect_via_webrtc(
     };
 
     let optional_config = response.into_inner().config;
-    let config = webrtc::extend_webrtc_config(webrtc_options.config, optional_config);
+    let (base_config, optional_config) = webrtc::apply_ice_policy(
+        webrtc_options.config,
+        optional_config,
+        webrtc_options.force_relay,
+        webrtc_options.force_p2p,
+    );
+    let mut config = webrtc::extend_webrtc_config(base_config, optional_config);
+    if let Some(host) = &webrtc_options.relay_host_filter {
+        config = webrtc::filter_ice_servers_by_host(config, host);
+    }
 
     let (peer_connection, data_channel) =
         webrtc::new_peer_connection_for_client(config, webrtc_options.disable_trickle_ice).await?;

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -616,12 +616,8 @@ impl DialBuilder<WithoutCredentials> {
         let original_uri2 = duplicate_uri(&original_uri).ok_or(anyhow::anyhow!(
             "Attempting to connect but there was no uri"
         ))?;
-        let skip_mdns = self.config.disable_mdns
-            || self
-                .config
-                .webrtc_options
-                .as_ref()
-                .is_some_and(|o| o.force_relay);
+
+        let skip_mdns = self.config.disable_mdns;
 
         // We want to short circuit and return the first `Ok` result from our connection
         // attempts, which `tokio::select!` does great. Buuuuut, we don't want to
@@ -630,7 +626,7 @@ impl DialBuilder<WithoutCredentials> {
         // the same future multiple times, while the loop lets us immediately return on the
         // first `Ok` result while still seeing and logging any error results.
         //
-        // When mDNS is skipped (disable_mdns or force_relay), with_mdns_err is pre-set so
+        // When mDNS is skipped (disable_mdns), with_mdns_err is pre-set so
         // the select guard disables that branch and only the direct connection is attempted.
         tokio::pin! {
             let with_mdns = self.clone().connect_mdns(original_uri);
@@ -821,12 +817,7 @@ impl DialBuilder<WithCredentials> {
             "Attempting to connect but there was no uri"
         ))?;
 
-        let skip_mdns = self.config.disable_mdns
-            || self
-                .config
-                .webrtc_options
-                .as_ref()
-                .is_some_and(|o| o.force_relay);
+        let skip_mdns = self.config.disable_mdns;
 
         // We want to short circuit and return the first `Ok` result from our connection
         // attempts, which `tokio::select!` does great. Buuuuut, we don't want to
@@ -835,7 +826,7 @@ impl DialBuilder<WithCredentials> {
         // the same future multiple times, while the loop lets us immediately return on the
         // first `Ok` result while still seeing and logging any error results.
         //
-        // When mDNS is skipped (disable_mdns or force_relay), with_mdns_err is pre-set so
+        // When mDNS is skipped (disable_mdns), with_mdns_err is pre-set so
         // the select guard disables that branch and only the direct connection is attempted.
         tokio::pin! {
             let with_mdns = self.clone().connect_mdns(original_uri);

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -339,16 +339,15 @@ impl<T: AuthMethod> DialBuilder<T> {
     }
 
     /// Filters the signaling server's TURN list to only the server whose parsed URI
-    /// matches. Uses struct comparison identical to the server-side TURN_URI env var.
-    /// Example: "turn:turn.viam.com:443"
-    pub fn turn_uri(mut self, uri: impl Into<String>) -> Self {
+    /// matches (compared by scheme, host, port, and transport — defaulting transport
+    /// to UDP if unspecified). Example: "turn:turn.viam.com:443"
+    pub fn turn_uri(mut self, uri: String) -> Self {
         self.config
             .webrtc_options
             .get_or_insert_with(Options::default)
-            .turn_uri = Some(uri.into());
+            .turn_uri = Some(uri);
         self
     }
-
 
     /// Overrides the signaling server address used for WebRTC negotiation.
     /// Useful for testing against a specific app deployment (e.g. a Cloud Run PR deploy).

--- a/src/rpc/webrtc.rs
+++ b/src/rpc/webrtc.rs
@@ -45,11 +45,9 @@ pub(crate) struct Options {
     /// candidates are used. Useful for testing direct connectivity without relay fallback.
     pub(crate) force_p2p: bool,
     /// When set, filters the signaling server's TURN list to only the server whose
-    /// parsed URI matches. Uses struct comparison identical to the server-side TURN_URI
-    /// env var. Leave transport unspecified for UDP default.
-    /// Example: "turn:turn.viam.com:443"
+    /// parsed URI matches (compared by scheme, host, port, and transport — defaulting
+    /// transport to UDP if unspecified). Example: "turn:turn.viam.com:443"
     pub(crate) turn_uri: Option<String>,
-
 }
 
 impl fmt::Debug for Options {
@@ -143,8 +141,6 @@ impl TurnUri {
             transport,
         })
     }
-
-
 }
 
 /// Filters TURN server URLs in config to only those whose parsed URI matches turn_uri.
@@ -153,9 +149,9 @@ pub(crate) fn apply_turn_options(
     mut config: RTCConfiguration,
     turn_uri: Option<&TurnUri>,
 ) -> RTCConfiguration {
-    if turn_uri.is_none() {
+    let Some(filter) = turn_uri else {
         return config;
-    }
+    };
     for server in &mut config.ice_servers {
         server.urls = server
             .urls
@@ -165,10 +161,8 @@ pub(crate) fn apply_turn_options(
                     return Some(url.clone());
                 }
                 let uri = TurnUri::parse(url)?;
-                if let Some(filter) = turn_uri {
-                    if &uri != filter {
-                        return None;
-                    }
+                if &uri != filter {
+                    return None;
                 }
                 Some(url.clone())
             })

--- a/src/rpc/webrtc.rs
+++ b/src/rpc/webrtc.rs
@@ -160,10 +160,7 @@ pub(crate) fn apply_turn_options(
                 if !url.starts_with("turn:") && !url.starts_with("turns:") {
                     return Some(url.clone());
                 }
-                let Some(uri) = TurnUri::parse(url) else {
-                    log::warn!("Failed to parse TURN URL {url:?}; dropping from ICE config");
-                    return None;
-                };
+                let uri = TurnUri::parse(url)?;
                 if &uri != filter {
                     return None;
                 }

--- a/src/rpc/webrtc.rs
+++ b/src/rpc/webrtc.rs
@@ -105,11 +105,10 @@ impl Options {
         self.disable_webrtc = true;
         self
     }
-
 }
 
 /// A parsed TURN URI with scheme, host, port, and transport components.
-/// Transport defaults to "udp" when unspecified, matching stun.ParseURI behavior.
+/// Transport defaults to "udp" when unspecified.
 #[derive(Debug, PartialEq)]
 pub(crate) struct TurnUri {
     pub scheme: String,

--- a/src/rpc/webrtc.rs
+++ b/src/rpc/webrtc.rs
@@ -44,8 +44,6 @@ pub(crate) struct Options {
     /// Strips TURN servers from the ICE configuration so only host and server-reflexive
     /// candidates are used. Useful for testing direct connectivity without relay fallback.
     pub(crate) force_p2p: bool,
-    /// When set, retains only ICE servers whose URLs contain this host string.
-    pub(crate) relay_host_filter: Option<String>,
 }
 
 impl fmt::Debug for Options {
@@ -104,12 +102,6 @@ impl Options {
         self
     }
 
-}
-
-/// Retains only ICE servers whose URLs contain the given host string.
-pub(crate) fn filter_ice_servers_by_host(mut config: RTCConfiguration, host: &str) -> RTCConfiguration {
-    config.ice_servers.retain(|s| s.urls.iter().any(|url| url.contains(host)));
-    config
 }
 
 /// Returns true if any of the ICE server's URLs use a TURN scheme.

--- a/src/rpc/webrtc.rs
+++ b/src/rpc/webrtc.rs
@@ -45,8 +45,6 @@ pub(crate) struct Options {
     /// candidates are used. Useful for testing direct connectivity without relay fallback.
     pub(crate) force_p2p: bool,
     /// When set, retains only ICE servers whose URLs contain this host string.
-    /// Applied after the full ICE server list is assembled. Useful for isolating
-    /// a specific TURN server (e.g. coturn) when multiple are provided.
     pub(crate) relay_host_filter: Option<String>,
 }
 
@@ -77,8 +75,7 @@ impl Options {
         // TODO(RSDK-235): remove hard coding of signaling server address and prefer SRV lookup instead
         let path = uri.to_string();
         if path.contains(".viam.cloud") {
-            // Hard-code localhost:8081 into here so that we use the local version of app.
-            Some(("localhost:8081".to_string(), false))
+            Some(("app.viam.com:443".to_string(), true))
         } else if path.contains(".robot.viaminternal") {
             Some(("app.viaminternal:8089".to_string(), false))
         } else {
@@ -119,12 +116,17 @@ impl Options {
         self
     }
 
-    /// Retains only ICE servers whose URLs contain the given host string, applied after
-    /// the full ICE server list is assembled. Useful for isolating a specific TURN server.
+    /// Retains only ICE servers whose URLs contain the given host string.
     pub(crate) fn relay_host_filter(mut self, host: String) -> Self {
         self.relay_host_filter = Some(host);
         self
     }
+}
+
+/// Retains only ICE servers whose URLs contain the given host string.
+pub(crate) fn filter_ice_servers_by_host(mut config: RTCConfiguration, host: &str) -> RTCConfiguration {
+    config.ice_servers.retain(|s| s.urls.iter().any(|url| url.contains(host)));
+    config
 }
 
 /// Returns true if any of the ICE server's URLs use a TURN scheme.
@@ -132,15 +134,6 @@ pub(crate) fn ice_server_has_turn(s: &RTCIceServer) -> bool {
     s.urls
         .iter()
         .any(|url| url.starts_with("turn:") || url.starts_with("turns:"))
-}
-
-/// Retains only ICE servers whose URLs contain the given host string.
-pub(crate) fn filter_ice_servers_by_host(
-    mut config: RTCConfiguration,
-    host: &str,
-) -> RTCConfiguration {
-    config.ice_servers.retain(|s| s.urls.iter().any(|url| url.contains(host)));
-    config
 }
 
 /// Applies force_relay or force_p2p options to a config and optional server config.

--- a/src/rpc/webrtc.rs
+++ b/src/rpc/webrtc.rs
@@ -44,10 +44,12 @@ pub(crate) struct Options {
     /// Strips TURN servers from the ICE configuration so only host and server-reflexive
     /// candidates are used. Useful for testing direct connectivity without relay fallback.
     pub(crate) force_p2p: bool,
-    /// When set, filters the assembled ICE server list to only TURN servers whose URL
-    /// contains this substring. Non-TURN servers are unaffected. Can be combined with
-    /// force_relay to route through a specific TURN server.
-    pub(crate) relay_host_filter: Option<String>,
+    /// When set, filters the signaling server's TURN list to only the server whose
+    /// parsed URI matches. Uses struct comparison identical to the server-side TURN_URI
+    /// env var. Leave transport unspecified for UDP default.
+    /// Example: "turn:turn.viam.com:443"
+    pub(crate) turn_uri: Option<String>,
+
 }
 
 impl fmt::Debug for Options {
@@ -108,15 +110,72 @@ impl Options {
 
 }
 
-/// Removes TURN servers from config whose URLs do not contain host.
-/// Non-TURN servers are left unchanged.
-pub(crate) fn filter_ice_servers_by_host(mut config: RTCConfiguration, host: &str) -> RTCConfiguration {
-    config.ice_servers.retain(|s| {
-        if !ice_server_has_turn(s) {
-            return true;
+/// A parsed TURN URI with scheme, host, port, and transport components.
+/// Transport defaults to "udp" when unspecified, matching stun.ParseURI behavior.
+#[derive(Debug, PartialEq)]
+pub(crate) struct TurnUri {
+    pub scheme: String,
+    pub host: String,
+    pub port: u16,
+    pub transport: String,
+}
+
+impl TurnUri {
+    /// Parses a TURN URI string of the form "scheme:host:port?transport=proto".
+    /// Returns None for non-TURN URIs or malformed input.
+    pub fn parse(s: &str) -> Option<Self> {
+        let (scheme, rest) = s.split_once(':')?;
+        if scheme != "turn" && scheme != "turns" {
+            return None;
         }
-        s.urls.iter().any(|url| url.contains(host))
-    });
+        let (hostport, query) = rest.split_once('?').unwrap_or((rest, ""));
+        let (host, port_str) = hostport.rsplit_once(':')?;
+        let port = port_str.parse().ok()?;
+        let transport = query
+            .split('&')
+            .find_map(|p| p.strip_prefix("transport="))
+            .unwrap_or("udp")
+            .to_string();
+        Some(TurnUri {
+            scheme: scheme.to_string(),
+            host: host.to_string(),
+            port,
+            transport,
+        })
+    }
+
+
+}
+
+/// Filters TURN server URLs in config to only those whose parsed URI matches turn_uri.
+/// Non-TURN URLs (e.g. stun:) are always kept unchanged.
+pub(crate) fn apply_turn_options(
+    mut config: RTCConfiguration,
+    turn_uri: Option<&TurnUri>,
+) -> RTCConfiguration {
+    if turn_uri.is_none() {
+        return config;
+    }
+    for server in &mut config.ice_servers {
+        server.urls = server
+            .urls
+            .iter()
+            .filter_map(|url| {
+                if !url.starts_with("turn:") && !url.starts_with("turns:") {
+                    return Some(url.clone());
+                }
+                let uri = TurnUri::parse(url)?;
+                if let Some(filter) = turn_uri {
+                    if &uri != filter {
+                        return None;
+                    }
+                }
+                Some(url.clone())
+            })
+            .collect();
+    }
+    // Remove ICE server entries that had all their TURN URLs filtered out.
+    config.ice_servers.retain(|s| !s.urls.is_empty());
     config
 }
 

--- a/src/rpc/webrtc.rs
+++ b/src/rpc/webrtc.rs
@@ -44,6 +44,10 @@ pub(crate) struct Options {
     /// Strips TURN servers from the ICE configuration so only host and server-reflexive
     /// candidates are used. Useful for testing direct connectivity without relay fallback.
     pub(crate) force_p2p: bool,
+    /// When set, filters the assembled ICE server list to only TURN servers whose URL
+    /// contains this substring. Non-TURN servers are unaffected. Can be combined with
+    /// force_relay to route through a specific TURN server.
+    pub(crate) relay_host_filter: Option<String>,
 }
 
 impl fmt::Debug for Options {
@@ -102,6 +106,18 @@ impl Options {
         self
     }
 
+}
+
+/// Removes TURN servers from config whose URLs do not contain host.
+/// Non-TURN servers are left unchanged.
+pub(crate) fn filter_ice_servers_by_host(mut config: RTCConfiguration, host: &str) -> RTCConfiguration {
+    config.ice_servers.retain(|s| {
+        if !ice_server_has_turn(s) {
+            return true;
+        }
+        s.urls.iter().any(|url| url.contains(host))
+    });
+    config
 }
 
 /// Returns true if any of the ICE server's URLs use a TURN scheme.

--- a/src/rpc/webrtc.rs
+++ b/src/rpc/webrtc.rs
@@ -21,6 +21,7 @@ use webrtc::{
     interceptor::registry::Registry,
     peer_connection::{
         configuration::RTCConfiguration, peer_connection_state::RTCPeerConnectionState,
+        policy::ice_transport_policy::RTCIceTransportPolicy,
         sdp::session_description::RTCSessionDescription, signaling_state::RTCSignalingState,
         RTCPeerConnection,
     },
@@ -37,6 +38,16 @@ pub(crate) struct Options {
     pub(crate) config: RTCConfiguration,
     pub(crate) signaling_insecure: bool,
     pub(crate) signaling_server_address: String,
+    /// Forces ICE transport policy to relay-only, so only TURN candidates are used.
+    /// Useful for testing relay connectivity through a TURN server.
+    pub(crate) force_relay: bool,
+    /// Strips TURN servers from the ICE configuration so only host and server-reflexive
+    /// candidates are used. Useful for testing direct connectivity without relay fallback.
+    pub(crate) force_p2p: bool,
+    /// When set, retains only ICE servers whose URLs contain this host string.
+    /// Applied after the full ICE server list is assembled. Useful for isolating
+    /// a specific TURN server (e.g. coturn) when multiple are provided.
+    pub(crate) relay_host_filter: Option<String>,
 }
 
 impl fmt::Debug for Options {
@@ -66,7 +77,8 @@ impl Options {
         // TODO(RSDK-235): remove hard coding of signaling server address and prefer SRV lookup instead
         let path = uri.to_string();
         if path.contains(".viam.cloud") {
-            Some(("app.viam.com:443".to_string(), true))
+            // Hard-code localhost:8081 into here so that we use the local version of app.
+            Some(("localhost:8081".to_string(), false))
         } else if path.contains(".robot.viaminternal") {
             Some(("app.viaminternal:8089".to_string(), false))
         } else {
@@ -94,6 +106,58 @@ impl Options {
         self.disable_webrtc = true;
         self
     }
+
+    /// Forces ICE transport policy to relay-only (only TURN candidates considered).
+    pub(crate) fn force_relay(mut self) -> Self {
+        self.force_relay = true;
+        self
+    }
+
+    /// Strips TURN servers from the ICE config so only host/srflx candidates are used.
+    pub(crate) fn force_p2p(mut self) -> Self {
+        self.force_p2p = true;
+        self
+    }
+
+    /// Retains only ICE servers whose URLs contain the given host string, applied after
+    /// the full ICE server list is assembled. Useful for isolating a specific TURN server.
+    pub(crate) fn relay_host_filter(mut self, host: String) -> Self {
+        self.relay_host_filter = Some(host);
+        self
+    }
+}
+
+/// Returns true if any of the ICE server's URLs use a TURN scheme.
+pub(crate) fn ice_server_has_turn(s: &RTCIceServer) -> bool {
+    s.urls
+        .iter()
+        .any(|url| url.starts_with("turn:") || url.starts_with("turns:"))
+}
+
+/// Retains only ICE servers whose URLs contain the given host string.
+pub(crate) fn filter_ice_servers_by_host(
+    mut config: RTCConfiguration,
+    host: &str,
+) -> RTCConfiguration {
+    config.ice_servers.retain(|s| s.urls.iter().any(|url| url.contains(host)));
+    config
+}
+
+/// Applies force_relay or force_p2p options to a config and optional server config.
+pub(crate) fn apply_ice_policy(
+    mut config: RTCConfiguration,
+    mut optional: Option<WebRtcConfig>,
+    force_relay: bool,
+    force_p2p: bool,
+) -> (RTCConfiguration, Option<WebRtcConfig>) {
+    if force_p2p {
+        optional = None;
+        config.ice_servers.retain(|s| !ice_server_has_turn(s));
+    }
+    if force_relay {
+        config.ice_transport_policy = RTCIceTransportPolicy::Relay;
+    }
+    (config, optional)
 }
 
 fn default_configuration() -> RTCConfiguration {

--- a/src/rpc/webrtc.rs
+++ b/src/rpc/webrtc.rs
@@ -160,7 +160,10 @@ pub(crate) fn apply_turn_options(
                 if !url.starts_with("turn:") && !url.starts_with("turns:") {
                     return Some(url.clone());
                 }
-                let uri = TurnUri::parse(url)?;
+                let Some(uri) = TurnUri::parse(url) else {
+                    log::warn!("Failed to parse TURN URL {url:?}; dropping from ICE config");
+                    return None;
+                };
                 if &uri != filter {
                     return None;
                 }

--- a/src/rpc/webrtc.rs
+++ b/src/rpc/webrtc.rs
@@ -104,23 +104,6 @@ impl Options {
         self
     }
 
-    /// Forces ICE transport policy to relay-only (only TURN candidates considered).
-    pub(crate) fn force_relay(mut self) -> Self {
-        self.force_relay = true;
-        self
-    }
-
-    /// Strips TURN servers from the ICE config so only host/srflx candidates are used.
-    pub(crate) fn force_p2p(mut self) -> Self {
-        self.force_p2p = true;
-        self
-    }
-
-    /// Retains only ICE servers whose URLs contain the given host string.
-    pub(crate) fn relay_host_filter(mut self, host: String) -> Self {
-        self.relay_host_filter = Some(host);
-        self
-    }
 }
 
 /// Retains only ICE servers whose URLs contain the given host string.


### PR DESCRIPTION
## Description

[RSDK-13658](https://viam.atlassian.net/browse/RSDK-13658) figure out why metrics change in coturn caused rustutils failure.

Part of changes investigating why `rust-utils` panics when dialing against Coturn `latest`. Adds diagnostic tooling to reproduce and test signaling/ICE scenarios. (The underlying stun panic is not fixed in this PR). These changes can be used for future testing of `rust-utils` dial code against all signaling paths / coturn changes.

* Add a suite of `viam-dialdbg` flags / WebRTC `DialOptions` for targeted WebRTC/TURN testing:
    * `--force-relay` sets ICE policy to only use relay candidates
    * `--force-p2p` strips TURN servers from the ICE config so only host/srflx candidates are used
    * `--signaling-server` overrides the app/signaling address returned by `infer_remote_uri_from_authority`
    * `--disable-mdns` causes mDNS paths to return early
    * `--turn-uri <uri>` filters the signaling server's TURN list to only the server matching the given URI (compared by scheme, host, port, and transport — defaulting transport to UDP if omitted). Example: `turn:turn.viam.com:443`
* Update `stats.rs` report to print the nominated ICE candidate pair (looked up via `CandidatePair.nominated`) and include `candidate_type` in the output, followed by all gathered candidates.
* Add a test script (`src/dialdbg/test-relay-and-p2p-dial-opts.sh`) that runs six end-to-end scenarios covering baseline, `--force-relay`, `--turn-uri`, `--force-p2p`, and an expected-failure case.
* Fix panic in `stats.rs`: use `cand.timestamp.elapsed()` instead of `now.duration_since(cand.timestamp)`, which panics when the candidate timestamp is newer than `now`


## Testing

- [x] `cargo build --features dialdbg` compiles cleanly
- [x] `viam-dialdbg --force-relay` establishes a relay-only connection
- [x] `viam-dialdbg --force-p2p` connects without any TURN relay
- [x] `viam-dialdbg --turn-uri <uri>` with `--force-relay` routes through the matched TURN server
- [x] `viam-dialdbg --turn-uri turn:notexist.example.com:3478` with `--force-relay` fails (no relay candidates)
- [x] `viam-dialdbg --signaling-server <addr>` dials against a specific app instance
- [x] `--force-relay` and `--force-p2p` are mutually exclusive 
### Validated Test Suite

Tested against a prod and local robot and signaling server. The test script checks the `candidate type` field in `viam-dialdbg`'s nominated pair stats output to confirm the flags are actually respected by the ICE stack.

<details>
<summary>Test script (<code>src/dialdbg/test-relay-and-p2p-dial-opts.sh</code>)</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail

cargo build --features dialdbg --bin viam-dialdbg 2>&1 | tail -1
BINARY=./target/debug/viam-dialdbg

HOST="<machine-fqdn>"
ENTITY="<api-key-id>"
APIKEY="<api-key>"
# TURN_URI should be the URI of a TURN server returned by the signaling server.
# Example: "turn:turn.viam.com:443"
TURN_URI="<turn-uri>"
COMMON=(-u "$HOST" -e "$ENTITY" -t api-key -c "$APIKEY" --nogrpc --nortt)

PASS=0
FAIL=0

# Extract the local ICE candidate type from dialdbg output.
# Stats print "local ICE candidate:" followed by fields including "candidate type: <type>".
# We grab the type value on the line immediately after the local candidate header.
local_candidate_type() {
  awk '/\tlocal ICE candidate:/{found=1} found && /candidate type:/{print $NF; found=0}' <<< "$1" | head -1
}

assert() {
  local name="$1" output="$2" want_type="$3"  # want_type: "relay", "!relay", or "none"
  printf '\n=== %s ===\n' "$name"
  printf '%s\n' "$output"

  local actual
  actual=$(local_candidate_type "$output")

  if [[ "$want_type" == "none" ]]; then
    # Expect connection failure — no candidates should be nominated.
    if [[ -z "$actual" ]]; then
      printf 'PASS: no candidates nominated (expected failure)\n'
      ((++PASS))
    else
      printf 'FAIL: expected no candidates, got local candidate type: %s\n' "$actual"
      ((++FAIL))
    fi
  elif [[ "$want_type" == "!relay" ]]; then
    # Expect a successful non-relay connection.
    if [[ -n "$actual" && "$actual" != "relay" ]]; then
      printf 'PASS: local candidate type: %s (not relay)\n' "$actual"
      ((++PASS))
    elif [[ -z "$actual" ]]; then
      printf 'FAIL: connection failed (no candidates nominated)\n'
      ((++FAIL))
    else
      printf 'FAIL: expected non-relay candidate, got: %s\n' "$actual"
      ((++FAIL))
    fi
  else
    # Expect a specific candidate type (e.g. "relay").
    if [[ "$actual" == "$want_type" ]]; then
      printf 'PASS: local candidate type: %s\n' "$actual"
      ((++PASS))
    elif [[ -z "$actual" ]]; then
      printf 'FAIL: connection failed (no candidates nominated)\n'
      ((++FAIL))
    else
      printf 'FAIL: expected candidate type %s, got: %s\n' "$want_type" "$actual"
      ((++FAIL))
    fi
  fi
}

run() {
  "$BINARY" "${COMMON[@]}" "$@" 2>/dev/null || true
}

# 1. Baseline — expect non-relay (host or srflx)
assert "baseline (no flags)" "$(run)" "!relay"

# 2. ForceRelay — expect relay
assert "ForceRelay" "$(run --force-relay)" "relay"

# 3. ForceRelay + TurnUri matching a valid TURN server — expect relay
assert "ForceRelay + TurnUri" "$(run --force-relay --turn-uri "$TURN_URI")" "relay"

# 4. ForceP2P — expect non-relay (host or srflx)
assert "ForceP2P" "$(run --force-p2p)" "!relay"

# 5. TurnUri alone — filters TURN options but ICE still picks host/srflx; expect non-relay
assert "TurnUri (no ForceRelay)" "$(run --turn-uri "$TURN_URI")" "!relay"

# 6. ForceRelay + non-matching TurnUri — all TURN filtered out, no relay candidates, expect failure
assert "ForceRelay + TurnUri=notexist (expect: fail)" "$(run --force-relay --turn-uri "turn:notexist.example.com:3478")" "none"

printf '\n%d passed, %d failed.\n' "$PASS" "$FAIL"
[[ $FAIL -eq 0 ]]
```

Run with:
```bash
./src/dialdbg/test-relay-and-p2p-dial-opts.sh
```

Expected output:
```
=== baseline (no flags) ===
...
PASS: local candidate type: host (not relay)

=== ForceRelay ===
...
PASS: local candidate type: relay

=== ForceRelay + TurnUri ===
...
PASS: local candidate type: relay

=== ForceP2P ===
...
PASS: local candidate type: host (not relay)

=== TurnUri (no ForceRelay) ===
...
PASS: local candidate type: host (not relay)

=== ForceRelay + TurnUri=notexist (expect: fail) ===
...
PASS: no candidates nominated (expected failure)

6 passed, 0 failed.
```

</details>

[RSDK-13658]: https://viam.atlassian.net/browse/RSDK-13658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ