### PR TITLE
Add staging signaling server address inference

### DIFF
--- a/src/rpc/webrtc.rs
+++ b/src/rpc/webrtc.rs
@@ -80,6 +80,8 @@ impl Options {
             Some(("app.viam.com:443".to_string(), true))
         } else if path.contains(".robot.viaminternal") {
             Some(("app.viaminternal:8089".to_string(), false))
+        } else if path.contains(".viamstg.cloud") {
+            Some(("app.viam.dev:443".to_string(), true))
         } else {
             None
         }


### PR DESCRIPTION
Adds inference of `app.viam.dev:443` as the signaling server address for `.viamstg.cloud` hosts, matching the Go implementation in [rdk](https://github.com/viamrobotics/rdk/blob/e97399c1a14f630c8f11f5854c14fdf56860ddd3/grpc/dial.go#L45).

The existing `.viam.cloud` and `.robot.viaminternal` cases are unchanged.