### PR TITLE
Fix mDNS dial to downgrade to plaintext for insecure connections

### DIFF
--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -565,14 +565,35 @@ impl<T: AuthMethod> DialBuilder<T> {
             // `my-robot.abcdefg.viam.cloud`) used for SNI and SAN verification.
             log::debug!("mDNS create_channel: connecting to {host} with TLS");
             let tls_config = ClientTlsConfig::new().domain_name(domain);
-            let mut parts = uri.into_parts();
+            let mut parts = uri.clone().into_parts();
             parts.scheme = Some(Scheme::HTTPS);
-            let uri = Uri::from_parts(parts)?;
-            return Channel::builder(uri.clone())
+            let tls_uri = Uri::from_parts(parts)?;
+            match Channel::builder(tls_uri.clone())
                 .tls_config(tls_config)?
                 .connect()
                 .await
-                .with_context(|| format!("Connecting to {:?}", uri));
+                .with_context(|| format!("Connecting to {:?}", tls_uri))
+            {
+                Ok(channel) => return Ok(channel),
+                // When the caller allows insecure/downgrade, retry the local connection over plaintext
+                // instead of failing. A local viam-server with no TLS serves plain gRPC on the advertised
+                // port, so the TLS handshake above fails against it.
+                Err(e) => {
+                    if allow_downgrade {
+                        let mut parts = uri.into_parts();
+                        parts.scheme = Some(Scheme::HTTP);
+                        let uri = Uri::from_parts(parts)?;
+                        log::debug!(
+                            "mDNS TLS connect failed ({e:#}); downgrading to plaintext h2c {uri:?}"
+                        );
+                        return Channel::builder(uri.clone())
+                            .connect()
+                            .await
+                            .with_context(|| format!("Connecting to {:?}", uri));
+                    }
+                    return Err(e);
+                }
+            }
         }
 
         let chan = match Channel::builder(uri.clone())


### PR DESCRIPTION
## Problem

Dialing a local/insecure viam-server by an mDNS-discoverable name [fails](https://github.com/viamrobotics/sdk-integration-tests/actions/runs/27197793239/job/80293802919). `viam-server` advertises a loopback address over mDNS and serves plaintext gRPC there, but the mDNS branch of `create_channel` unconditionally forces TLS:

```rust
parts.scheme = Some(Scheme::HTTPS);
Channel::builder(uri).tls_config(tls_config)?.connect().await
```

so the TLS handshake always failed against the plaintext server. This regressed in #180 (RSDK-13879), which removed the earlier `is_loopback -> h2c` branch.

## Fix

On the mDNS path, attempt TLS first (unchanged for cloud robots with real certs); if it fails and the caller allowed an insecure/downgraded connection, retry the local connection over plaintext.

## Testing

- `cargo build` / `cargo clippy --all-features`: clean (no new warnings).
- Local/insecure viam-server dialed with and without fix to observe dial failure and fix.