### PR TITLE
rpc: disable mDNS when force_relay or force_p2p is set

### DIFF
--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -326,6 +326,10 @@ impl<T: AuthMethod> DialBuilder<T> {
             .webrtc_options
             .get_or_insert_with(Options::default)
             .force_relay = true;
+        // Forcing relay-only ICE is pointless if the dial short-circuits to a
+        // local mDNS connection (plain gRPC over LAN/loopback that bypasses
+        // WebRTC/ICE entirely), so disable mDNS as well.
+        self.config.disable_mdns = true;
         self
     }
 
@@ -336,6 +340,10 @@ impl<T: AuthMethod> DialBuilder<T> {
             .webrtc_options
             .get_or_insert_with(Options::default)
             .force_p2p = true;
+        // Forcing host/srflx-only ICE is pointless if the dial short-circuits to
+        // a local mDNS connection (plain gRPC over LAN/loopback that bypasses
+        // WebRTC/ICE entirely), so disable mDNS as well.
+        self.config.disable_mdns = true;
         self
     }
 


### PR DESCRIPTION
## Problem
`force_relay` / `force_p2p` exist to force a connection through a specific WebRTC transport (relay-only TURN, or host/srflx-only). But the dialer attempts mDNS local discovery first, and when the target machine is reachable on the LAN/loopback it connects via plain gRPC over mDNS — bypassing WebRTC/ICE entirely and silently ignoring `force_relay`/`force_p2p`.

Observed in the SDK dial-options integration tests against the Python SDK (which dials via these FFI bindings): a `force_relay` connection that should route through TURN instead connected locally over mDNS (no relay `candidate_pair` ever appears), and a `force_relay` connection with a deliberately-invalid TURN URI (which must fail) succeeded over mDNS. `RUST_LOG=debug` showed `Starting mDNS query` → `Found address via mDNS` → `mDNS create_channel: loopback 127.0.0.1` with no TURN allocation.

## Fix
Disable mDNS in the `force_relay()` and `force_p2p()` builders. Since the FFI (`viam_dial_opts_set_force_relay`/`viam_dial_opts_set_force_p2p`) routes through these builders, Python/C consumers pick this up automatically (a `viam-python-sdk` bundled-rust-utils bump is the follow-up to ship it). Mirrors the Go dialer behavior.

Draft for review/discussion.