### PR TITLE
RSDK-654 - refactor message handling for streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3873,6 +3873,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.23.4",
  "tokio-stream",
+ "tokio-util",
  "tonic",
  "tonic-build",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ serde_json = "1.0"
 tokio = {version = "1.19", features = ["rt-multi-thread", "time", "fs", "macros", "net"]}
 tokio-stream = {version = "0.1", features = ["net"]}
 tokio-rustls = { version = "0.23.4"}
+tokio-util = "0.7"
 tonic = {version = "0.9.2",features = [ "tls", "gzip", "tls-roots","tls-webpki-roots"]}
 tower = { version = "0.4" }
 tower-http = { version = "0.3.3", features = ["add-extension","auth","propagate-header","set-header","sensitive-headers","trace","compression-gzip"]}

--- a/src/rpc/base_channel.rs
+++ b/src/rpc/base_channel.rs
@@ -7,6 +7,7 @@ use std::{
         Arc,
     },
 };
+use tokio_util::sync::CancellationToken;
 use webrtc::{
     data_channel::RTCDataChannel, ice_transport::ice_connection_state::RTCIceConnectionState,
     peer_connection::RTCPeerConnection,
@@ -19,6 +20,10 @@ pub struct WebRTCBaseChannel {
     pub(crate) data_channel: Arc<RTCDataChannel>,
     closed_reason: AtomicPtr<Option<anyhow::Error>>,
     closed: AtomicBool,
+    // Cancelled when the channel closes (locally via `close`, or when the data channel
+    // closes/errors). Lets detached tasks tied to this channel — e.g. the outbound
+    // request-body pump — abort instead of parking forever and pinning the channel alive.
+    pub(crate) closed_token: CancellationToken,
 }
 
 impl Debug for WebRTCBaseChannel {
@@ -68,11 +73,24 @@ impl WebRTCBaseChannel {
             data_channel,
             closed_reason: AtomicPtr::new(&mut None),
             closed: AtomicBool::new(false),
+            closed_token: CancellationToken::new(),
         });
 
+        // Cancel the token when the data channel closes so that tasks tied to this
+        // channel unblock even if the peer connection dies remotely. The token is a
+        // cheap, independent allocation, so moving a clone into the handler does not
+        // keep the channel Arc alive.
+        let close_token = channel.closed_token.clone();
+        dc.on_close(Box::new(move || {
+            close_token.cancel();
+            Box::pin(async {})
+        }));
+
         let c = Arc::downgrade(&channel);
+        let error_token = channel.closed_token.clone();
         dc.on_error(Box::new(move |err: webrtc::Error| {
             log::error!("Data channel error: {err}");
+            error_token.cancel();
             let c = match c.upgrade() {
                 Some(c) => c,
                 None => return Box::pin(async {}),
@@ -94,6 +112,7 @@ impl WebRTCBaseChannel {
             return Ok(());
         }
         self.closed.store(true, Ordering::Release);
+        self.closed_token.cancel();
 
         self.peer_connection
             .close()

--- a/src/rpc/client_channel.rs
+++ b/src/rpc/client_channel.rs
@@ -186,90 +186,65 @@ impl WebRTCClientChannel {
         self.send(&header_vec).await
     }
 
-    pub(crate) async fn write_message(
-        &self,
-        stream: Option<Stream>,
-        mut data: Vec<u8>,
-    ) -> Result<()> {
-        // even if no meaningful data, any actual message will include at least frame header bytes
-        let has_message = !data.is_empty();
+    /// Sends a single complete gRPC-framed message (1-byte compression flag + 4-byte
+    /// big-endian length + payload), packetizing the payload across multiple Requests
+    /// when it exceeds MAX_REQUEST_MESSAGE_PACKET_DATA_SIZE. The caller is responsible
+    /// for splitting a body into individual gRPC messages and for signaling end of
+    /// stream via `write_eos` once all messages have been sent.
+    pub(crate) async fn write_grpc_message(&self, stream: &Stream, data: &[u8]) -> Result<()> {
+        if data.len() < 5 {
+            return Err(anyhow::anyhow!(
+                "Attempted to process message with irregular length"
+            ));
+        }
 
-        // rust libraries are munging streamed client requests into a single http request.
-        // we can look at the gRPC header bytes to determine the length of the first message
-        // and compare it to the length of the data to determine whether this http request
-        // is a single unary call, or a streaming call.
-        // TODO(RSDK-654) The munging of streaming requests into a single http request is
-        // likely going to cause problems for us when we encounter a need for bidi streaming
-        // in the real world. Look into how we can fix it, and hopefully get rid of this
-        // header math in the process.
-
-        let mut to_add_bytes = [0u8; 4];
-
-        // always run the loop at least once, check at completion if we've sent all data and
-        // break the loop accordingly
+        // 1..5 are the gRPC length-prefix bytes; strip the 5-byte header and packetize
+        // the payload. The webrtc eom/eos framing replaces the gRPC framing on the wire.
+        let mut payload = &data[5..];
         loop {
-            if data.len() < 5 {
-                return Err(anyhow::anyhow!(
-                    "Attempted to process message with irregular length"
-                ));
+            let split_at = MAX_REQUEST_MESSAGE_PACKET_DATA_SIZE.min(payload.len());
+            let (to_send, remaining) = payload.split_at(split_at);
+            let eom = remaining.is_empty();
+            let request = Request {
+                stream: Some(stream.clone()),
+                r#type: Some(Type::Message(RequestMessage {
+                    has_message: true,
+                    eos: false,
+                    packet_message: Some(PacketMessage {
+                        eom,
+                        data: to_send.to_vec(),
+                    }),
+                })),
+            };
+
+            let request = Message::encode_to_vec(&request);
+            if let Err(e) = self.send(&request).await {
+                log::error!("error sending message: {e}");
+                return Err(e);
             }
 
-            // because we might have multiple requests contained within our data, we have
-            // to do the manual work of breaking apart the body into separate requests.
-
-            // 1-5 because those are the length header bytes for gRPC
-            to_add_bytes.clone_from_slice(&data[1..5]);
-            let mut next_message_length: usize =
-                u32::from_be_bytes(to_add_bytes).try_into().unwrap();
-
-            data = data.split_off(5);
-            // we need an internal loop because a single message may be longer than the
-            // MAX_REQUEST_MESSAGE_PACKET_DATA_SIZE in which case we don't want to shave off
-            // a five byte header. but, a single call to write_message may contain multiple
-            // distinct messages within the data vec, so we want to be able to evaluate length
-            // multiple times if necessary. we use a loop with an exit check at the bottom
-            // because we always want to send a request at least once, even if the data is empty.
-            loop {
-                let split_at = MAX_REQUEST_MESSAGE_PACKET_DATA_SIZE
-                    .min(data.len())
-                    .min(next_message_length);
-                let (to_send, remaining) = data.split_at(split_at);
-                next_message_length -= split_at;
-                let stream = stream.clone();
-                let eos = remaining.is_empty();
-                let request = Request {
-                    stream,
-                    r#type: Some(Type::Message(RequestMessage {
-                        has_message,
-                        // note(ethan): the variable name that used to exist for determining `eos` was
-                        // `it_was_all_a_stream`. Which isn't important at all, but
-                        // `it_was_all_a_stream` is the best variable name I've ever shipped into
-                        // production and it makes me sad to see it go, so I wanted to memorialize
-                        // it somehow!
-                        eos,
-                        packet_message: Some(PacketMessage {
-                            eom: next_message_length == 0 || eos,
-                            data: to_send.to_vec(),
-                        }),
-                    })),
-                };
-
-                let request = Message::encode_to_vec(&request);
-                if let Err(e) = self.send(&request).await {
-                    log::error!("error sending message: {e}");
-                    return Err(e);
-                }
-
-                data = remaining.to_vec();
-                if next_message_length == 0 {
-                    break;
-                }
-            }
-            if data.is_empty() {
+            payload = remaining;
+            if eom {
                 break;
             }
         }
         Ok(())
+    }
+
+    /// Signals the end of the client's send stream (the gRPC CloseSend equivalent).
+    // note(ethan): the variable that used to carry this signal was named
+    // `it_was_all_a_stream` — the best variable name I've ever shipped into production.
+    // Memorialized here so it is not forgotten.
+    pub(crate) async fn write_eos(&self, stream: &Stream) -> Result<()> {
+        let request = Request {
+            stream: Some(stream.clone()),
+            r#type: Some(Type::Message(RequestMessage {
+                has_message: false,
+                eos: true,
+                packet_message: None,
+            })),
+        };
+        self.send(&Message::encode_to_vec(&request)).await
     }
 
     async fn send(&self, data: &[u8]) -> Result<()> {

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -112,12 +112,21 @@ impl ViamChannel {
             status_code = STATUS_CODE_UNKNOWN;
         }
 
-        let data = hyper::body::to_bytes(body).await.unwrap().to_vec();
-        if let Err(e) = channel.write_message(Some(stream), data).await {
-            log::error!("error sending message: {e}");
-            channel.close_stream_with_recv_error(stream_id, e);
-            status_code = STATUS_CODE_UNKNOWN;
-        };
+        // Pump the request body to the data channel on its own task so that response
+        // frames (delivered async via on_channel_message into the resp body) can flow
+        // back to the caller WHILE requests are still being sent. Required for
+        // client-streaming and bidi; previously we drained the whole body with
+        // `to_bytes` before returning the response, which serialized send-then-receive.
+        if status_code == STATUS_CODE_OK {
+            let send_channel = channel.clone();
+            let send_stream = stream.clone();
+            tokio::spawn(async move {
+                if let Err(e) = pump_request_body(&send_channel, &send_stream, body).await {
+                    log::error!("error sending message: {e}");
+                    send_channel.close_stream_with_recv_error(stream_id, e);
+                }
+            });
+        }
 
         let body = match channel.resp_body_from_stream(stream_id) {
             Ok(body) => body,
@@ -137,6 +146,49 @@ impl ViamChannel {
 
         response.body(body).unwrap()
     }
+}
+
+/// Reads `body` frame-by-frame, reassembling complete gRPC-framed messages across
+/// hyper frame boundaries and forwarding each to the data channel as soon as it is
+/// complete, then signals end of stream. Streaming the body (rather than buffering it
+/// whole with `to_bytes`) is what lets client requests interleave with server
+/// responses, enabling client-streaming and bidi.
+async fn pump_request_body(
+    channel: &Arc<WebRTCClientChannel>,
+    stream: &crate::gen::proto::rpc::webrtc::v1::Stream,
+    mut body: BoxBody,
+) -> Result<()> {
+    use http_body::Body as _;
+
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = body.data().await {
+        let chunk = chunk.map_err(|e| anyhow::anyhow!("error reading request body: {e}"))?;
+        buf.extend_from_slice(&chunk);
+
+        // Emit every complete gRPC message currently buffered. A gRPC frame is a
+        // 1-byte compression flag + 4-byte big-endian length + payload.
+        loop {
+            if buf.len() < 5 {
+                break;
+            }
+            let len = u32::from_be_bytes(buf[1..5].try_into().unwrap()) as usize;
+            let total = 5 + len;
+            if buf.len() < total {
+                break; // message spans further frames; wait for the rest
+            }
+            let msg: Vec<u8> = buf.drain(..total).collect();
+            channel.write_grpc_message(stream, &msg).await?;
+        }
+    }
+
+    if !buf.is_empty() {
+        return Err(anyhow::anyhow!(
+            "request body ended with {} trailing bytes of an incomplete message",
+            buf.len()
+        ));
+    }
+
+    channel.write_eos(stream).await
 }
 
 impl Service<http::Request<BoxBody>> for ViamChannel {

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -160,9 +160,29 @@ async fn pump_request_body(
 ) -> Result<()> {
     use http_body::Body as _;
 
+    // Abort the pump if the underlying connection dies. `body.data()` polls the
+    // app-side request body, which is independent of the data channel, so without
+    // this a dead connection with an idle-but-open send half would park this task
+    // forever while it pins the channel Arc alive. Built once outside the loop so the
+    // hot send path does not re-register a waiter on every message.
+    let cancelled = channel.base_channel.closed_token.clone().cancelled_owned();
+    tokio::pin!(cancelled);
+
     let mut buf: Vec<u8> = Vec::new();
-    while let Some(chunk) = body.data().await {
-        let chunk = chunk.map_err(|e| anyhow::anyhow!("error reading request body: {e}"))?;
+    loop {
+        let chunk = tokio::select! {
+            biased;
+            _ = &mut cancelled => {
+                return Err(anyhow::anyhow!(
+                    "connection closed before request body completed; aborting send"
+                ));
+            }
+            chunk = body.data() => chunk,
+        };
+        let chunk = match chunk {
+            Some(chunk) => chunk.map_err(|e| anyhow::anyhow!("error reading request body: {e}"))?,
+            None => break, // body complete
+        };
         buf.extend_from_slice(&chunk);
 
         // Emit every complete gRPC message currently buffered. A gRPC frame is a


### PR DESCRIPTION
Refactors message handling to send messages asynchronously as soon as they come in, defer sending EOS until client messages are demonstrably completed, and only as its own frame.