### PR TITLE
APP-14871: Report WebRTC connection metadata after dialing

### DIFF
--- a/src/gen/proto.rpc.webrtc.v1.rs
+++ b/src/gen/proto.rpc.webrtc.v1.rs
@@ -375,4 +375,210 @@ pub struct OptionalWebRtcConfigResponse {
     #[prost(message, optional, tag="1")]
     pub config: ::core::option::Option<WebRtcConfig>,
 }
+/// ConnectionCandidate describes the selected ICE candidate for one side of a WebRTC connection.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ConnectionCandidate {
+    #[prost(enumeration="IceCandidateType", tag="1")]
+    pub r#type: i32,
+    /// relay_address is the relay server address of this candidate; set only when type is
+    /// RELAY, so the signaling server can classify the provider by matching against known
+    /// coturn addresses.
+    #[prost(string, tag="2")]
+    pub relay_address: ::prost::alloc::string::String,
+}
+/// ReportConnectionMetadataRequest reports metadata about a WebRTC dial, per side: local is the
+/// dialing SDK and remote is the robot.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReportConnectionMetadataRequest {
+    #[prost(message, optional, tag="1")]
+    pub local: ::core::option::Option<ConnectionCandidate>,
+    #[prost(message, optional, tag="2")]
+    pub remote: ::core::option::Option<ConnectionCandidate>,
+    #[prost(enumeration="SdkType", tag="3")]
+    pub sdk_type: i32,
+    /// reached_stage is the furthest dial checkpoint reached. READY indicates success; any earlier
+    /// value is where a failed dial stopped.
+    #[prost(enumeration="DialStage", tag="4")]
+    pub reached_stage: i32,
+    /// duration_ms is the wall-clock time from dial start to connection ready or to the failure.
+    #[prost(uint32, tag="5")]
+    pub duration_ms: u32,
+    /// signaling_path is how the dial was signaled (cloud / local / mDNS); reported regardless of outcome.
+    #[prost(enumeration="ConnectionSignalingPath", tag="6")]
+    pub signaling_path: i32,
+    /// failure_code is the gRPC status code of a failed dial
+    #[prost(int32, tag="7")]
+    pub failure_code: i32,
+    /// sdk_version is the version of the dialing SDK (e.g. a semver or git tag).
+    #[prost(string, tag="8")]
+    pub sdk_version: ::prost::alloc::string::String,
+}
+/// ReportConnectionMetadataResponse is empty.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReportConnectionMetadataResponse {
+}
+/// ICECandidateType represents the type of ICE candidate selected for a WebRTC connection.
+/// The signaling server further classifies RELAY by relay server specific provider from the address.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum IceCandidateType {
+    Unspecified = 0,
+    /// ICE_CANDIDATE_TYPE_HOST indicates a direct connection was established.
+    Host = 1,
+    /// ICE_CANDIDATE_TYPE_STUN indicates a STUN-assisted connection was established.
+    Stun = 2,
+    /// ICE_CANDIDATE_TYPE_RELAY indicates a TURN relay candidate was selected.
+    Relay = 3,
+}
+impl IceCandidateType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            IceCandidateType::Unspecified => "ICE_CANDIDATE_TYPE_UNSPECIFIED",
+            IceCandidateType::Host => "ICE_CANDIDATE_TYPE_HOST",
+            IceCandidateType::Stun => "ICE_CANDIDATE_TYPE_STUN",
+            IceCandidateType::Relay => "ICE_CANDIDATE_TYPE_RELAY",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "ICE_CANDIDATE_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
+            "ICE_CANDIDATE_TYPE_HOST" => Some(Self::Host),
+            "ICE_CANDIDATE_TYPE_STUN" => Some(Self::Stun),
+            "ICE_CANDIDATE_TYPE_RELAY" => Some(Self::Relay),
+            _ => None,
+        }
+    }
+}
+/// SDKType represents the Viam SDK used to establish the connection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum SdkType {
+    Unspecified = 0,
+    Go = 1,
+    Typescript = 2,
+    PythonCpp = 3,
+}
+impl SdkType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            SdkType::Unspecified => "SDK_TYPE_UNSPECIFIED",
+            SdkType::Go => "SDK_TYPE_GO",
+            SdkType::Typescript => "SDK_TYPE_TYPESCRIPT",
+            SdkType::PythonCpp => "SDK_TYPE_PYTHON_CPP",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "SDK_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
+            "SDK_TYPE_GO" => Some(Self::Go),
+            "SDK_TYPE_TYPESCRIPT" => Some(Self::Typescript),
+            "SDK_TYPE_PYTHON_CPP" => Some(Self::PythonCpp),
+            _ => None,
+        }
+    }
+}
+/// DialStage is the furthest checkpoint a WebRTC dial reached. READY means the dial succeeded; any
+/// earlier value is the stage at which a failed dial stopped.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum DialStage {
+    Unspecified = 0,
+    /// DIAL_STAGE_SIGNALING_CONNECTED: the signaling channel was established.
+    SignalingConnected = 1,
+    /// DIAL_STAGE_CONFIG_FETCHED: ICE/TURN configuration was fetched from the signaling server.
+    ConfigFetched = 2,
+    /// DIAL_STAGE_OFFER_SENT: the SDP offer was sent to the signaling server (the Call was accepted).
+    OfferSent = 3,
+    /// DIAL_STAGE_ANSWER_RECEIVED: the answerer's SDP answer was received and applied.
+    AnswerReceived = 4,
+    /// DIAL_STAGE_ICE_CONNECTED: ICE connectivity was established (a candidate pair connected).
+    IceConnected = 5,
+    /// DIAL_STAGE_DTLS_CONNECTED: the DTLS handshake completed (peer connection connected) but the
+    /// data channel is not yet open.
+    DtlsConnected = 6,
+    /// DIAL_STAGE_READY: the connection is fully ready (data channel open). This is success.
+    Ready = 7,
+}
+impl DialStage {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            DialStage::Unspecified => "DIAL_STAGE_UNSPECIFIED",
+            DialStage::SignalingConnected => "DIAL_STAGE_SIGNALING_CONNECTED",
+            DialStage::ConfigFetched => "DIAL_STAGE_CONFIG_FETCHED",
+            DialStage::OfferSent => "DIAL_STAGE_OFFER_SENT",
+            DialStage::AnswerReceived => "DIAL_STAGE_ANSWER_RECEIVED",
+            DialStage::IceConnected => "DIAL_STAGE_ICE_CONNECTED",
+            DialStage::DtlsConnected => "DIAL_STAGE_DTLS_CONNECTED",
+            DialStage::Ready => "DIAL_STAGE_READY",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "DIAL_STAGE_UNSPECIFIED" => Some(Self::Unspecified),
+            "DIAL_STAGE_SIGNALING_CONNECTED" => Some(Self::SignalingConnected),
+            "DIAL_STAGE_CONFIG_FETCHED" => Some(Self::ConfigFetched),
+            "DIAL_STAGE_OFFER_SENT" => Some(Self::OfferSent),
+            "DIAL_STAGE_ANSWER_RECEIVED" => Some(Self::AnswerReceived),
+            "DIAL_STAGE_ICE_CONNECTED" => Some(Self::IceConnected),
+            "DIAL_STAGE_DTLS_CONNECTED" => Some(Self::DtlsConnected),
+            "DIAL_STAGE_READY" => Some(Self::Ready),
+            _ => None,
+        }
+    }
+}
+/// ConnectionSignalingPath is how a WebRTC dial was signaled, derived from the signaling address.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ConnectionSignalingPath {
+    Unspecified = 0,
+    /// CONNECTION_SIGNALING_PATH_CLOUD_SIGNALED: signaled through app's signaling server.
+    CloudSignaled = 1,
+    /// CONNECTION_SIGNALING_PATH_MDNS_LOCAL: signaled over an mDNS-discovered local-network path.
+    MdnsLocal = 2,
+    /// CONNECTION_SIGNALING_PATH_LOCAL: signaled through a loopback/private-address signaling server
+    /// (e.g. a machine's own signaling server) without mDNS discovery.
+    Local = 3,
+}
+impl ConnectionSignalingPath {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            ConnectionSignalingPath::Unspecified => "CONNECTION_SIGNALING_PATH_UNSPECIFIED",
+            ConnectionSignalingPath::CloudSignaled => "CONNECTION_SIGNALING_PATH_CLOUD_SIGNALED",
+            ConnectionSignalingPath::MdnsLocal => "CONNECTION_SIGNALING_PATH_MDNS_LOCAL",
+            ConnectionSignalingPath::Local => "CONNECTION_SIGNALING_PATH_LOCAL",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "CONNECTION_SIGNALING_PATH_UNSPECIFIED" => Some(Self::Unspecified),
+            "CONNECTION_SIGNALING_PATH_CLOUD_SIGNALED" => Some(Self::CloudSignaled),
+            "CONNECTION_SIGNALING_PATH_MDNS_LOCAL" => Some(Self::MdnsLocal),
+            "CONNECTION_SIGNALING_PATH_LOCAL" => Some(Self::Local),
+            _ => None,
+        }
+    }
+}
 // @@protoc_insertion_point(module)

--- a/src/gen/proto.rpc.webrtc.v1.tonic.rs
+++ b/src/gen/proto.rpc.webrtc.v1.tonic.rs
@@ -193,6 +193,36 @@ pub mod signaling_service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        pub async fn report_connection_metadata(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ReportConnectionMetadataRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::ReportConnectionMetadataResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/proto.rpc.webrtc.v1.SignalingService/ReportConnectionMetadata",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "proto.rpc.webrtc.v1.SignalingService",
+                        "ReportConnectionMetadata",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -234,6 +264,13 @@ pub mod signaling_service_server {
             request: tonic::Request<super::OptionalWebRtcConfigRequest>,
         ) -> std::result::Result<
             tonic::Response<super::OptionalWebRtcConfigResponse>,
+            tonic::Status,
+        >;
+        async fn report_connection_metadata(
+            &self,
+            request: tonic::Request<super::ReportConnectionMetadataRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::ReportConnectionMetadataResponse>,
             tonic::Status,
         >;
     }
@@ -483,6 +520,54 @@ pub mod signaling_service_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = OptionalWebRTCConfigSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/proto.rpc.webrtc.v1.SignalingService/ReportConnectionMetadata" => {
+                    #[allow(non_camel_case_types)]
+                    struct ReportConnectionMetadataSvc<T: SignalingService>(pub Arc<T>);
+                    impl<
+                        T: SignalingService,
+                    > tonic::server::UnaryService<super::ReportConnectionMetadataRequest>
+                    for ReportConnectionMetadataSvc<T> {
+                        type Response = super::ReportConnectionMetadataResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::ReportConnectionMetadataRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                (*inner).report_connection_metadata(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ReportConnectionMetadataSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/src/rpc/dial.rs
+++ b/src/rpc/dial.rs
@@ -1,5 +1,6 @@
 use super::{
     client_channel::*,
+    dial_report::{classify_signaling_path, report_dial_outcome, DialStageTracker},
     log_prefixes,
     webrtc::{webrtc_action_with_timeout, Options},
 };
@@ -9,8 +10,8 @@ use crate::gen::proto::rpc::v1::{
 };
 use crate::gen::proto::rpc::webrtc::v1::{
     call_response::Stage, call_update_request::Update,
-    signaling_service_client::SignalingServiceClient, CallUpdateRequest,
-    OptionalWebRtcConfigRequest, OptionalWebRtcConfigResponse,
+    signaling_service_client::SignalingServiceClient, CallUpdateRequest, ConnectionSignalingPath,
+    DialStage, OptionalWebRtcConfigRequest, OptionalWebRtcConfigResponse,
 };
 use crate::gen::proto::rpc::webrtc::v1::{
     CallRequest, IceCandidate, Metadata, RequestHeaders, Strings,
@@ -711,6 +712,7 @@ impl DialBuilder<WithoutCredentials> {
         mdns_uri: Option<Parts>,
         mut original_uri_parts: Parts,
     ) -> Result<ViamChannel> {
+        let dial_start = Instant::now();
         let webrtc_options = self.config.webrtc_options;
         let disable_webrtc = match &webrtc_options {
             Some(options) => options.disable_webrtc,
@@ -780,7 +782,16 @@ impl DialBuilder<WithoutCredentials> {
             log::debug!("{}", log_prefixes::DIALED_GRPC);
             Ok(ViamChannel::Direct(channel.clone()))
         } else {
-            match maybe_connect_via_webrtc(uri, intercepted_channel.clone(), webrtc_options).await {
+            let signaling_path = classify_signaling_path(&uri);
+            match maybe_connect_via_webrtc(
+                uri,
+                intercepted_channel.clone(),
+                webrtc_options,
+                dial_start,
+                signaling_path,
+            )
+            .await
+            {
                 Ok(webrtc_channel) => Ok(ViamChannel::WebRTC(webrtc_channel)),
                 Err(e) => {
                     log::error!("error connecting via webrtc: {e}. Attempting to connect directly");
@@ -897,6 +908,7 @@ impl DialBuilder<WithCredentials> {
         mdns_uri: Option<Parts>,
         mut original_uri_parts: Parts,
     ) -> Result<ViamChannel> {
+        let dial_start = Instant::now();
         let is_insecure = self.config.insecure;
 
         let webrtc_options = self.config.webrtc_options;
@@ -916,6 +928,7 @@ impl DialBuilder<WithCredentials> {
             original_uri.clone(),
             self.config.signaling_server_override.as_deref(),
         );
+        let signaling_path = classify_signaling_path(&uri_for_auth);
 
         let mdns_uri = mdns_uri.and_then(|p| Uri::from_parts(p).ok());
         let attempting_mdns = mdns_uri.is_some();
@@ -982,7 +995,15 @@ impl DialBuilder<WithCredentials> {
             log::debug!("Connected via gRPC");
             Ok(ViamChannel::DirectPreAuthorized(channel))
         } else {
-            match maybe_connect_via_webrtc(original_uri, channel.clone(), webrtc_options).await {
+            match maybe_connect_via_webrtc(
+                original_uri,
+                channel.clone(),
+                webrtc_options,
+                dial_start,
+                signaling_path,
+            )
+            .await
+            {
                 Ok(webrtc_channel) => Ok(ViamChannel::WebRTC(webrtc_channel)),
                 Err(e) => {
                     log::error!(
@@ -1148,18 +1169,53 @@ impl fmt::Display for CallerUpdateStats {
     }
 }
 
+/// Attempts a WebRTC dial and, win or lose, reports the outcome (furthest stage reached,
+/// duration, signaling path, selected candidate pair, failure code) to the signaling server it
+/// dialed through, mirroring the Go SDK's connection-metadata telemetry. The report is
+/// best-effort and detached, so it neither delays the caller's direct-connection fallback nor
+/// surfaces errors of its own.
 async fn maybe_connect_via_webrtc(
     uri: Uri,
     channel: AddAuthorization<SetRequestHeader<Channel, HeaderValue>>,
     webrtc_options: Option<Options>,
+    dial_start: Instant,
+    signaling_path: ConnectionSignalingPath,
 ) -> Result<Arc<WebRTCClientChannel>> {
+    let stage = Arc::new(DialStageTracker::new());
+    let result = connect_via_webrtc(uri, channel.clone(), webrtc_options, stage.clone()).await;
+    let peer_connection = result
+        .as_ref()
+        .ok()
+        .map(|client_channel| client_channel.base_channel.peer_connection.clone());
+    report_dial_outcome(
+        channel,
+        peer_connection,
+        &stage,
+        dial_start,
+        signaling_path,
+        result.as_ref().err(),
+    );
+    result
+}
+
+async fn connect_via_webrtc(
+    uri: Uri,
+    channel: AddAuthorization<SetRequestHeader<Channel, HeaderValue>>,
+    webrtc_options: Option<Options>,
+    dial_stage: Arc<DialStageTracker>,
+) -> Result<Arc<WebRTCClientChannel>> {
+    // The caller already established the channel to the signaling server.
+    dial_stage.advance(DialStage::SignalingConnected);
     let webrtc_options = webrtc_options.unwrap_or_else(|| Options::infer_from_uri(uri.clone()));
     let mut signaling_client = SignalingServiceClient::new(channel.clone());
     let response = match signaling_client
         .optional_web_rtc_config(OptionalWebRtcConfigRequest::default())
         .await
     {
-        Ok(resp) => resp,
+        Ok(resp) => {
+            dial_stage.advance(DialStage::ConfigFetched);
+            resp
+        }
         Err(e) => {
             if e.code() == tonic::Code::Unimplemented {
                 tonic::Response::new(OptionalWebRtcConfigResponse::default())
@@ -1210,8 +1266,12 @@ async fn maybe_connect_via_webrtc(
         log::debug!("TURN filter options set: turn_uri={uri:?}");
     }
 
-    let (peer_connection, data_channel) =
-        webrtc::new_peer_connection_for_client(config, webrtc_options.disable_trickle_ice).await?;
+    let (peer_connection, data_channel) = webrtc::new_peer_connection_for_client(
+        config,
+        webrtc_options.disable_trickle_ice,
+        dial_stage.clone(),
+    )
+    .await?;
 
     let sent_done_or_error = Arc::new(AtomicBool::new(false));
     let uuid_lock = Arc::new(RwLock::new("".to_string()));
@@ -1234,6 +1294,27 @@ async fn maybe_connect_via_webrtc(
     let ice_done2 = ice_done.clone();
     let caller_update_stats = Arc::new(Mutex::new(CallerUpdateStats::default()));
 
+    {
+        let caller_update_stats = caller_update_stats.clone();
+        let dial_stage = dial_stage.clone();
+        peer_connection.on_ice_connection_state_change(Box::new(
+            move |state: RTCIceConnectionState| {
+                if state == RTCIceConnectionState::Connected
+                    || state == RTCIceConnectionState::Completed
+                {
+                    dial_stage.advance(DialStage::IceConnected);
+                }
+                let caller_update_stats = caller_update_stats.clone();
+                Box::pin(async move {
+                    if state == RTCIceConnectionState::Completed {
+                        let caller_update_stats_inner = caller_update_stats.lock().unwrap();
+                        log::debug!("{}", caller_update_stats_inner);
+                    }
+                })
+            },
+        ));
+    }
+
     if !webrtc_options.disable_trickle_ice {
         let offer = peer_connection.create_offer(None).await?;
         let channel2 = channel.clone();
@@ -1244,19 +1325,7 @@ async fn maybe_connect_via_webrtc(
 
         let on_local_ice_candidate_failure = is_open_s.clone();
 
-        let caller_update_stats = caller_update_stats.clone();
         let caller_update_stats2 = caller_update_stats.clone();
-        peer_connection.on_ice_connection_state_change(Box::new(
-            move |state: RTCIceConnectionState| {
-                let caller_update_stats = caller_update_stats.clone();
-                Box::pin(async move {
-                    if state == RTCIceConnectionState::Completed {
-                        let caller_update_stats_inner = caller_update_stats.lock().unwrap();
-                        log::debug!("{}", caller_update_stats_inner);
-                    }
-                })
-            },
-        ));
         peer_connection.on_ice_candidate(Box::new(
             move |ice_candidate: Option<RTCIceCandidate>| {
                 if exchange_done.load(Ordering::Acquire) {
@@ -1390,9 +1459,11 @@ async fn maybe_connect_via_webrtc(
     let client_channel_for_ice_gathering_thread = Arc::downgrade(&client_channel);
     let mut signaling_client = SignalingServiceClient::new(channel.clone());
     let mut call_client = signaling_client.call(call_request).await?.into_inner();
+    dial_stage.advance(DialStage::OfferSent);
 
     let channel2 = channel.clone();
     let sent_done_or_error2 = sent_done_or_error.clone();
+    let dial_stage2 = dial_stage.clone();
     tokio::spawn(async move {
         let uuid = uuid_for_ice_gathering_thread;
         let client_channel = client_channel_for_ice_gathering_thread;
@@ -1476,6 +1547,7 @@ async fn maybe_connect_via_webrtc(
                             break;
                         }
                     }
+                    dial_stage2.advance(DialStage::AnswerReceived);
                     let _ = remote_description_set_s.send_replace(Some(()));
                     if webrtc_options.disable_trickle_ice {
                         send_done_once(sent_done.clone(), &response.uuid, channel2.clone()).await;
@@ -1547,6 +1619,7 @@ async fn maybe_connect_via_webrtc(
         }
     }
 
+    dial_stage.advance(DialStage::Ready);
     exchange_done.store(true, Ordering::Release);
     let uuid = uuid_lock.read().unwrap().to_string();
     send_done_once(sent_done_or_error, &uuid, channel.clone()).await;

--- a/src/rpc/dial_report.rs
+++ b/src/rpc/dial_report.rs
@@ -1,0 +1,396 @@
+//! Best-effort reporting of WebRTC dial outcomes to the signaling server, mirroring the Go
+//! SDK's connection-metadata telemetry (goutils rpc/wrtc_client_report.go). After a WebRTC
+//! dial finishes — success or failure — the dialing client reports how far the dial got, how
+//! it was signaled, how long it took, and (on success) which ICE candidate pair was selected.
+
+use std::sync::{
+    atomic::{AtomicI32, Ordering},
+    Arc,
+};
+use std::time::{Duration, Instant};
+
+use ::http::{HeaderValue, Uri};
+use ::webrtc::ice::candidate::{CandidatePairState, CandidateType};
+use ::webrtc::peer_connection::RTCPeerConnection;
+use ::webrtc::stats::{StatsReport, StatsReportType};
+use tonic::transport::Channel;
+use tower_http::auth::AddAuthorization;
+use tower_http::set_header::SetRequestHeader;
+
+use crate::gen::proto::rpc::webrtc::v1::{
+    signaling_service_client::SignalingServiceClient, ConnectionCandidate, ConnectionSignalingPath,
+    DialStage, IceCandidateType, ReportConnectionMetadataRequest, SdkType,
+};
+
+/// How long a best-effort report send may take before being abandoned.
+const REPORT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// DialStageTracker tracks the furthest checkpoint a WebRTC dial reached, so a failed dial can
+/// report where it stopped. It is advanced from the dial task and from candidate-exchange / ICE
+/// callbacks, so it is an atomic; advance only ever moves it forward.
+#[derive(Debug, Default)]
+pub(crate) struct DialStageTracker {
+    stage: AtomicI32,
+}
+
+impl DialStageTracker {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn advance(&self, stage: DialStage) {
+        let mut cur = self.stage.load(Ordering::Acquire);
+        while (stage as i32) > cur {
+            match self.stage.compare_exchange_weak(
+                cur,
+                stage as i32,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return,
+                Err(actual) => cur = actual,
+            }
+        }
+    }
+
+    pub(crate) fn reached(&self) -> DialStage {
+        DialStage::from_i32(self.stage.load(Ordering::Acquire)).unwrap_or(DialStage::Unspecified)
+    }
+}
+
+/// The Viam app signaling server hosts.
+const VIAM_CLOUD_SIGNALING_HOSTS: [&str; 2] = ["app.viam.com", "app.viam.dev"];
+
+/// Derives how a connection was signaled from the signaling server address: a Viam app
+/// signaling host is CLOUD_SIGNALED; everything else (localhost, private/LAN addresses, a
+/// machine's own signaling server, etc.) is LOCAL. WebRTC is never dialed over an
+/// mDNS-discovered path here (mDNS connections are direct gRPC), so MDNS_LOCAL is never
+/// reported by this SDK.
+pub(crate) fn classify_signaling_path(signaling_uri: &Uri) -> ConnectionSignalingPath {
+    let host = signaling_uri.host().unwrap_or_default().to_lowercase();
+    if VIAM_CLOUD_SIGNALING_HOSTS.contains(&host.as_str()) {
+        ConnectionSignalingPath::CloudSignaled
+    } else {
+        ConnectionSignalingPath::Local
+    }
+}
+
+/// Extracts the gRPC status code of a failed dial: the code of the first tonic status in the
+/// error chain, or Unknown when the failure was not a gRPC error.
+pub(crate) fn failure_code(err: &anyhow::Error) -> i32 {
+    for cause in err.chain() {
+        if let Some(status) = cause.downcast_ref::<tonic::Status>() {
+            return status.code() as i32;
+        }
+    }
+    tonic::Code::Unknown as i32
+}
+
+/// Inspects the selected ICE candidate pair and classifies each side into a
+/// ConnectionCandidate. Both are UNSPECIFIED when no succeeded, nominated pair exists.
+///
+/// We match on the nominated, succeeded pair rather than the transport's authoritative
+/// selected pair because webrtc-rs's get_selected_candidate_pair returns an opaque
+/// RTCIceCandidatePair (no accessors for its candidates). This is reliable here: webrtc-rs
+/// uses regular nomination (a single nominated pair) and we sample once at dial completion.
+pub(crate) fn classify_connection(
+    stats: &StatsReport,
+) -> (ConnectionCandidate, ConnectionCandidate) {
+    let pair = stats.reports.values().find_map(|s| {
+        if let StatsReportType::CandidatePair(p) = s {
+            if p.nominated && p.state == CandidatePairState::Succeeded {
+                return Some((p.local_candidate_id.clone(), p.remote_candidate_id.clone()));
+            }
+        }
+        None
+    });
+    let (local_id, remote_id) = pair.unwrap_or_default();
+    (
+        classify_candidate(stats, &local_id),
+        classify_candidate(stats, &remote_id),
+    )
+}
+
+/// Maps a single ICE candidate stat to a ConnectionCandidate; a missing or unrecognized
+/// candidate yields type UNSPECIFIED. Relay candidates carry the relay server address so the
+/// signaling server can classify the relay provider.
+fn classify_candidate(stats: &StatsReport, cand_id: &str) -> ConnectionCandidate {
+    let cand = stats.reports.get(cand_id).and_then(|s| match s {
+        StatsReportType::LocalCandidate(c) | StatsReportType::RemoteCandidate(c) => Some(c),
+        _ => None,
+    });
+    match cand {
+        Some(c) => match c.candidate_type {
+            CandidateType::Host => ConnectionCandidate {
+                r#type: IceCandidateType::Host as i32,
+                relay_address: String::new(),
+            },
+            CandidateType::ServerReflexive | CandidateType::PeerReflexive => ConnectionCandidate {
+                r#type: IceCandidateType::Stun as i32,
+                relay_address: String::new(),
+            },
+            CandidateType::Relay => ConnectionCandidate {
+                r#type: IceCandidateType::Relay as i32,
+                relay_address: c.ip.clone(),
+            },
+            CandidateType::Unspecified => ConnectionCandidate::default(),
+        },
+        None => ConnectionCandidate::default(),
+    }
+}
+
+/// Reports the outcome of one WebRTC dial to the signaling server it dialed through,
+/// best-effort: errors are logged, never surfaced. The send is spawned on a detached task with
+/// its own timeout so a failed dial's direct-connection fallback is not delayed and a report
+/// still goes out if the caller moves on. An Unimplemented failure means the remote has no
+/// WebRTC signaler — a fallback control flow, not a WebRTC failure — so it is never reported.
+pub(crate) fn report_dial_outcome(
+    channel: AddAuthorization<SetRequestHeader<Channel, HeaderValue>>,
+    peer_connection: Option<Arc<RTCPeerConnection>>,
+    stage: &DialStageTracker,
+    dial_start: Instant,
+    signaling_path: ConnectionSignalingPath,
+    failure: Option<&anyhow::Error>,
+) {
+    let code = match failure {
+        Some(err) => {
+            let code = failure_code(err);
+            if code == tonic::Code::Unimplemented as i32 {
+                return;
+            }
+            code
+        }
+        None => 0,
+    };
+    let reached_stage = stage.reached() as i32;
+    let duration_ms = u32::try_from(dial_start.elapsed().as_millis()).unwrap_or(u32::MAX);
+
+    tokio::spawn(async move {
+        let (local, remote) = match peer_connection {
+            Some(pc) => classify_connection(&pc.get_stats().await),
+            None => Default::default(),
+        };
+        let request = ReportConnectionMetadataRequest {
+            local: Some(local),
+            remote: Some(remote),
+            sdk_type: SdkType::PythonCpp as i32,
+            reached_stage,
+            duration_ms,
+            signaling_path: signaling_path as i32,
+            failure_code: code,
+            sdk_version: env!("CARGO_PKG_VERSION").to_string(),
+        };
+        let mut signaling_client = SignalingServiceClient::new(channel);
+        match tokio::time::timeout(
+            REPORT_TIMEOUT,
+            signaling_client.report_connection_metadata(request),
+        )
+        .await
+        {
+            Ok(Err(e)) => log::debug!("failed to report connection metadata: {e}"),
+            Err(_) => log::debug!("timed out reporting connection metadata"),
+            Ok(Ok(_)) => (),
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ::webrtc::stats::{ICECandidatePairStats, ICECandidateStats, RTCStatsType};
+    use std::collections::HashMap;
+    use tokio::time::Instant;
+
+    fn candidate_stats(id: &str, candidate_type: CandidateType, ip: &str) -> ICECandidateStats {
+        ICECandidateStats {
+            timestamp: Instant::now(),
+            stats_type: RTCStatsType::LocalCandidate,
+            id: id.to_string(),
+            candidate_type,
+            deleted: false,
+            ip: ip.to_string(),
+            network_type: Default::default(),
+            port: 0,
+            priority: 0,
+            relay_protocol: String::new(),
+            url: String::new(),
+        }
+    }
+
+    fn pair_stats(
+        local_id: &str,
+        remote_id: &str,
+        state: CandidatePairState,
+        nominated: bool,
+    ) -> ICECandidatePairStats {
+        ICECandidatePairStats {
+            timestamp: Instant::now(),
+            stats_type: RTCStatsType::CandidatePair,
+            id: format!("{local_id}-{remote_id}"),
+            local_candidate_id: local_id.to_string(),
+            remote_candidate_id: remote_id.to_string(),
+            state,
+            nominated,
+            packets_sent: 0,
+            packets_received: 0,
+            bytes_sent: 0,
+            bytes_received: 0,
+            last_packet_sent_timestamp: Instant::now(),
+            last_packet_received_timestamp: Instant::now(),
+            total_round_trip_time: 0.0,
+            current_round_trip_time: 0.0,
+            available_outgoing_bitrate: 0.0,
+            available_incoming_bitrate: 0.0,
+            requests_received: 0,
+            requests_sent: 0,
+            responses_received: 0,
+            responses_sent: 0,
+            consent_requests_sent: 0,
+            circuit_breaker_trigger_count: 0,
+            consent_expired_timestamp: Instant::now(),
+            first_request_timestamp: Instant::now(),
+            last_request_timestamp: Instant::now(),
+            retransmissions_sent: 0,
+        }
+    }
+
+    fn report(entries: Vec<(String, StatsReportType)>) -> StatsReport {
+        StatsReport {
+            reports: entries.into_iter().collect::<HashMap<_, _>>(),
+        }
+    }
+
+    #[test]
+    fn test_dial_stage_tracker_only_advances_forward() {
+        let tracker = DialStageTracker::new();
+        assert_eq!(tracker.reached(), DialStage::Unspecified);
+        tracker.advance(DialStage::ConfigFetched);
+        assert_eq!(tracker.reached(), DialStage::ConfigFetched);
+        tracker.advance(DialStage::SignalingConnected);
+        assert_eq!(tracker.reached(), DialStage::ConfigFetched);
+        tracker.advance(DialStage::Ready);
+        assert_eq!(tracker.reached(), DialStage::Ready);
+    }
+
+    #[test]
+    fn test_classify_signaling_path() {
+        for (uri, expected) in [
+            (
+                "https://app.viam.com:443",
+                ConnectionSignalingPath::CloudSignaled,
+            ),
+            (
+                "https://app.viam.dev",
+                ConnectionSignalingPath::CloudSignaled,
+            ),
+            (
+                "https://APP.VIAM.COM:443",
+                ConnectionSignalingPath::CloudSignaled,
+            ),
+            ("http://localhost:8080", ConnectionSignalingPath::Local),
+            ("http://127.0.0.1:9000", ConnectionSignalingPath::Local),
+            ("http://10.1.2.3:443", ConnectionSignalingPath::Local),
+            (
+                "https://my-robot.abc123.viam.cloud:443",
+                ConnectionSignalingPath::Local,
+            ),
+        ] {
+            let uri: Uri = uri.parse().unwrap();
+            assert_eq!(classify_signaling_path(&uri), expected, "uri: {uri}");
+        }
+    }
+
+    #[test]
+    fn test_failure_code() {
+        let status_err =
+            anyhow::Error::from(tonic::Status::not_found("robot offline")).context("dial failed");
+        assert_eq!(failure_code(&status_err), tonic::Code::NotFound as i32);
+
+        let plain_err = anyhow::anyhow!("timed out opening data channel");
+        assert_eq!(failure_code(&plain_err), tonic::Code::Unknown as i32);
+    }
+
+    #[test]
+    fn test_classify_connection_selects_nominated_succeeded_pair() {
+        let stats = report(vec![
+            (
+                "local-relay".to_string(),
+                StatsReportType::LocalCandidate(candidate_stats(
+                    "local-relay",
+                    CandidateType::Relay,
+                    "34.0.0.1",
+                )),
+            ),
+            (
+                "remote-host".to_string(),
+                StatsReportType::RemoteCandidate(candidate_stats(
+                    "remote-host",
+                    CandidateType::Host,
+                    "192.168.1.2",
+                )),
+            ),
+            (
+                "pair-failed".to_string(),
+                StatsReportType::CandidatePair(pair_stats(
+                    "other",
+                    "other",
+                    CandidatePairState::Failed,
+                    false,
+                )),
+            ),
+            (
+                "pair-selected".to_string(),
+                StatsReportType::CandidatePair(pair_stats(
+                    "local-relay",
+                    "remote-host",
+                    CandidatePairState::Succeeded,
+                    true,
+                )),
+            ),
+        ]);
+
+        let (local, remote) = classify_connection(&stats);
+        assert_eq!(local.r#type, IceCandidateType::Relay as i32);
+        assert_eq!(local.relay_address, "34.0.0.1");
+        assert_eq!(remote.r#type, IceCandidateType::Host as i32);
+        assert_eq!(remote.relay_address, "");
+    }
+
+    #[test]
+    fn test_classify_connection_no_selected_pair_is_unspecified() {
+        let stats = report(vec![(
+            "pair-waiting".to_string(),
+            StatsReportType::CandidatePair(pair_stats(
+                "a",
+                "b",
+                CandidatePairState::Waiting,
+                false,
+            )),
+        )]);
+        let (local, remote) = classify_connection(&stats);
+        assert_eq!(local.r#type, IceCandidateType::Unspecified as i32);
+        assert_eq!(remote.r#type, IceCandidateType::Unspecified as i32);
+    }
+
+    #[test]
+    fn test_classify_candidate_types() {
+        for (candidate_type, expected, expected_addr) in [
+            (CandidateType::Host, IceCandidateType::Host, ""),
+            (CandidateType::ServerReflexive, IceCandidateType::Stun, ""),
+            (CandidateType::PeerReflexive, IceCandidateType::Stun, ""),
+            (CandidateType::Relay, IceCandidateType::Relay, "5.6.7.8"),
+        ] {
+            let stats = report(vec![(
+                "c1".to_string(),
+                StatsReportType::LocalCandidate(candidate_stats("c1", candidate_type, "5.6.7.8")),
+            )]);
+            let got = classify_candidate(&stats, "c1");
+            assert_eq!(got.r#type, expected as i32, "type: {candidate_type}");
+            assert_eq!(got.relay_address, expected_addr, "type: {candidate_type}");
+        }
+
+        let stats = report(vec![]);
+        let got = classify_candidate(&stats, "missing");
+        assert_eq!(got.r#type, IceCandidateType::Unspecified as i32);
+    }
+}

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -3,5 +3,6 @@ mod base_stream;
 mod client_channel;
 mod client_stream;
 pub mod dial;
+mod dial_report;
 pub mod log_prefixes;
 mod webrtc;

--- a/src/rpc/webrtc.rs
+++ b/src/rpc/webrtc.rs
@@ -1,5 +1,6 @@
+use super::dial_report::DialStageTracker;
 use super::log_prefixes;
-use crate::gen::proto::rpc::webrtc::v1::{IceServer, ResponseTrailers, WebRtcConfig};
+use crate::gen::proto::rpc::webrtc::v1::{DialStage, IceServer, ResponseTrailers, WebRtcConfig};
 use anyhow::Result;
 use bytes::Bytes;
 use core::fmt;
@@ -276,6 +277,7 @@ fn create_invalid_sdp_err(err: serde_json::error::Error) -> webrtc::Error {
 pub(crate) async fn new_peer_connection_for_client(
     config: RTCConfiguration,
     disable_trickle_ice: bool,
+    dial_stage: Arc<DialStageTracker>,
 ) -> Result<(Arc<RTCPeerConnection>, Arc<RTCDataChannel>)> {
     let web_api = new_webrtc_api()?;
     let peer_connection = Arc::new(web_api.new_peer_connection(config).await?);
@@ -296,6 +298,8 @@ pub(crate) async fn new_peer_connection_for_client(
         move |connection: RTCPeerConnectionState| {
             log::info!("peer connection state change: {connection}");
             if connection == RTCPeerConnectionState::Connected {
+                // Connected means ICE and DTLS both completed; the data channel may not be open yet.
+                dial_stage.advance(DialStage::DtlsConnected);
                 log::debug!("{}", log_prefixes::DIALED_WEBRTC);
             }
             Box::pin(async move {})


### PR DESCRIPTION
### Description

[APP-14871](https://viam.atlassian.net/browse/APP-14871) Track coturn usage / WebRTC client connection telemetry — the Python/C++ SDK (rust-utils) port of the Go SDK's dial telemetry in [goutils #583](https://github.com/viamrobotics/goutils/pull/583). App-side receiver in [app #11316](https://github.com/viamrobotics/app/pull/11316).

**Depends on goutils #583**: the `SignalingService.ReportConnectionMetadata` proto additions. The committed `src/gen` stubs were generated from that PR's branch; once it merges and publishes to the BSR, `make buf` reproduces them.

**Client (`maybe_connect_via_webrtc`)** — after a WebRTC dial succeeds or fails, reports best-effort to the signaling server it dialed through:
- `reached_stage`: the furthest dial checkpoint, advanced as the dial progresses (`SIGNALING_CONNECTED → CONFIG_FETCHED → OFFER_SENT → ANSWER_RECEIVED → ICE_CONNECTED → DTLS_CONNECTED → READY`). `READY` means success; any earlier value is where a failed dial stopped. Tracked by a forward-only atomic (`DialStageTracker`) since checkpoints advance from the dial task, the ICE state callback, and the answer-processing task.
- `local` / `remote`: the selected ICE candidate pair classified per side as host / stun / relay from the peer connection stats (nominated + succeeded pair — webrtc-rs's `get_selected_candidate_pair` is opaque). Relay candidates carry the relay address so app can attribute the provider (Viam coturn vs Twilio).
- `failure_code`: the tonic status code of a failed dial (first status in the error chain; non-gRPC failures map to `Unknown`). Set only on failure.
- `signaling_path`: classified from the signaling server address the channel actually dialed (`app.viam.com` / `app.viam.dev` → `cloud_signaled`, anything else → `local`). WebRTC is never dialed over mDNS here (mDNS connections are direct gRPC, RSDK-14026), so `mdns_local` is never reported by this SDK.
- `duration_ms` (dial start → ready/failure) and `sdk_type=python_cpp` / `sdk_version` (the rust-utils crate version; the FFI layer cannot distinguish Python from C++ callers, hence the single combined type).
- The reporting code lives in its own `src/rpc/dial_report.rs`. The send is spawned detached with a 5s timeout so it never delays the caller — in particular a failed WebRTC dial's direct-connection fallback proceeds immediately.

**Reporting semantics vs Go** — one report per WebRTC dial attempt, success or failure:
- Go suppresses failure reports when the logical dial succeeds because its parallel mDNS/cloud race produces spurious `Canceled` failures from losing paths. rust-utils has no parallel WebRTC race (the mDNS branch never dials WebRTC), so there is nothing to dedup — a failed attempt's report *is* the signal, even when the dial then falls back to a direct gRPC connection. Suppressing on fallback success would hide nearly all WebRTC failures from Python/C++, since the fallback usually works.
- An `Unimplemented` failure (remote has no WebRTC signaler) is fallback control flow, not a WebRTC failure, and is never reported — mirroring Go's `ErrNoWebRTCSignaler` handling.
- A dial cancelled by the mDNS race winning drops the in-flight future before any report is built, so cancelled attempts stay silent, matching Go.

**Tests** — unit coverage in `dial_report.rs` for stage-tracker forward-only advancement, signaling-path classification, candidate/pair classification (host/stun/relay, relay address, no-pair, missing-candidate), and failure-code extraction.

### Testing
- `cargo build`, `cargo test --lib` (10/10), clippy and rustfmt clean on touched files.
- E2E against a goutils echo server built from goutils #583, with the server temporarily logging received reports:
  - Ran the existing `tests/echo_test.rs` suite (6/6 pass). Exactly **one** `ReportConnectionMetadata` per WebRTC dial, `OK` response.
  - Success report: `local/remote host↔host, sdk_type=python_cpp, reached_stage=READY, duration_ms=580, signaling_path=local, sdk_version=0.6.0`.
  - Forced-relay failure (no reachable TURN): dial fell back to direct as before, and reported `reached_stage=ANSWER_RECEIVED, failure_code=2 (Unknown), signaling_path=local`, candidates unspecified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APP-14871]: https://viam.atlassian.net/browse/APP-14871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ